### PR TITLE
Prevent playback speed updates during ads

### DIFF
--- a/src/ts/BitmovinYospacePlayerPolicy.ts
+++ b/src/ts/BitmovinYospacePlayerPolicy.ts
@@ -7,6 +7,7 @@ export interface BitmovinYospacePlayerPolicy {
   canSeekTo(seekTarget: number): number;
   canSkip(): number;
   canPause(): boolean;
+  canChangePlaybackSpeed(): boolean;
 }
 
 export class DefaultBitmovinYospacePlayerPolicy implements BitmovinYospacePlayerPolicy {
@@ -61,5 +62,9 @@ export class DefaultBitmovinYospacePlayerPolicy implements BitmovinYospacePlayer
 
   canPause(): boolean {
     return true;
+  }
+
+  canChangePlaybackSpeed(): boolean {
+    return !Boolean(this.player.ads.getActiveAd());
   }
 }

--- a/src/ts/YospaceAdManagement.ts
+++ b/src/ts/YospaceAdManagement.ts
@@ -479,8 +479,7 @@ export class BitmovinYospacePlayer implements PlayerAPI {
   }
 
   setPlaybackSpeed(speed: number): void {
-    // TODO: ask turner about that
-    if (this.isAdActive()) {
+    if (!this.playerPolicy.canChangePlaybackSpeed()) {
       return;
     }
 


### PR DESCRIPTION
## Description
When the ad starts we set the playback speed to 1 to ensure that the ad is not played too fast. We delegate the decision if we allow to change the playback speed during an ad to the implementation of the policy. Default policy don't allow that during an ad.

After the ad the last set playback speed will be applied.