### PR TITLE
Provide information about yospace in the module info

### DIFF
--- a/src/ts/YospaceAdManagement.ts
+++ b/src/ts/YospaceAdManagement.ts
@@ -938,7 +938,7 @@ export class BitmovinYospacePlayer implements PlayerAPI {
 
     getModuleInfo: () => {
       const moduleInfo = this.player.ads.getModuleInfo();
-      moduleInfo.name = moduleInfo.name + '-yospace-integration';
+      moduleInfo.name += '-yospace-integration';
       return moduleInfo;
     },
   };


### PR DESCRIPTION
## Description
To properly track (e.g. with conviva) that yospace is used, this PR will add information about yospace within the `ModuleInfo` of the ad module.