### PR TITLE
Fix large negative ad duration countdown between ads

### DIFF
--- a/src/ts/YospaceAdManagement.ts
+++ b/src/ts/YospaceAdManagement.ts
@@ -712,12 +712,16 @@ export class BitmovinYospacePlayer implements PlayerAPI {
     }
 
     const playerEvent = AdEventsFactory.createAdEvent(this.player, PlayerEvent.AdStarted, this.manager, this.getCurrentAd());
-    this.fireEvent<AdEvent>(playerEvent);
 
+    // Need to be set before fireEvent is fired as the UI will call getCurrentTime in the callback of the
+    // AdStarted event
     if (this.isLive()) {
       // save start position of an ad within a live stream to calculate the current time within the ad
       this.adStartedTimestamp = this.player.getCurrentTime();
     }
+
+    this.fireEvent<AdEvent>(playerEvent);
+
     // TODO: autoskip if available
   };
 


### PR DESCRIPTION
## Description
The ad duration within the UI was flashing a big negative number between ads during a live stream.

## Problem
The `adStartedTimestamp` was set too late as the UI calls `getCurrentTime` within the `AdStarted` callback which leads to a 'non-magic' value.

## Solution
Set `adStartedTimestamp` before firing the `AdStarted` event to ensure 'magic-time' mapping.