### PR TITLE
Fix AdBreakEvent.AdBreak.scheduleTime to be magic time

### DIFF
--- a/src/ts/YospaceAdManagement.ts
+++ b/src/ts/YospaceAdManagement.ts
@@ -676,7 +676,12 @@ export class BitmovinYospacePlayer implements PlayerAPI {
     this.player.setPlaybackSpeed(1);
 
     const adBreak = event.adBreak;
-    const playerEvent = AdEventsFactory.createAdBreakEvent(this.player, adBreak.adBreakIdentifier, this.toMagicTime(adBreak.startPosition), PlayerEvent.AdBreakStarted);
+    const playerEvent = AdEventsFactory.createAdBreakEvent(
+      this.player,
+      adBreak.adBreakIdentifier,
+      this.toMagicTime(adBreak.startPosition),
+      PlayerEvent.AdBreakStarted,
+    );
     this.fireEvent<AdBreakEvent>(playerEvent);
   };
 
@@ -711,7 +716,12 @@ export class BitmovinYospacePlayer implements PlayerAPI {
       });
     }
 
-    const playerEvent = AdEventsFactory.createAdEvent(this.player, PlayerEvent.AdStarted, this.manager, this.getCurrentAd());
+    const playerEvent = AdEventsFactory.createAdEvent(
+      this.player,
+      PlayerEvent.AdStarted,
+      this.manager,
+      this.getCurrentAd(),
+    );
 
     // Need to be set before fireEvent is fired as the UI will call getCurrentTime in the callback of the
     // AdStarted event
@@ -726,14 +736,24 @@ export class BitmovinYospacePlayer implements PlayerAPI {
   };
 
   private onAdFinished = (event: BYSAdEvent) => {
-    const playerEvent = AdEventsFactory.createAdEvent(this.player, PlayerEvent.AdFinished, this.manager, this.getCurrentAd());
+    const playerEvent = AdEventsFactory.createAdEvent(
+      this.player,
+      PlayerEvent.AdFinished,
+      this.manager,
+      this.getCurrentAd(),
+    );
     this.fireEvent<AdEvent>(playerEvent);
     this.adStartedTimestamp = null;
   };
 
   private onAdBreakFinished = (event: BYSAdBreakEvent) => {
     const adBreak = event.adBreak;
-    const playerEvent = AdEventsFactory.createAdBreakEvent(this.player, adBreak.adBreakIdentifier, this.toMagicTime(adBreak.startPosition), PlayerEvent.AdBreakFinished);
+    const playerEvent = AdEventsFactory.createAdBreakEvent(
+      this.player,
+      adBreak.adBreakIdentifier,
+      this.toMagicTime(adBreak.startPosition),
+      PlayerEvent.AdBreakFinished,
+    );
     this.fireEvent<AdBreakEvent>(playerEvent);
 
     if (this.cachedSeekTarget) {
@@ -1083,7 +1103,12 @@ class AdTranslator {
 }
 
 class AdEventsFactory {
-  static createAdBreakEvent(player: PlayerAPI, adBreakId: string, scheduleTime: number, type: PlayerEvent): AdBreakEvent {
+  static createAdBreakEvent(
+    player: PlayerAPI,
+    adBreakId: string,
+    scheduleTime: number,
+    type: PlayerEvent,
+  ): AdBreakEvent {
     return {
       timestamp: Date.now(),
       type: type,

--- a/tslint.json
+++ b/tslint.json
@@ -60,7 +60,7 @@
         "multiline": {
           "arrays": "always",
           "exports": "always",
-          "functions": "never",
+          "functions": "always",
           "imports": "always",
           "objects": "always",
           "typeLiterals": "always"


### PR DESCRIPTION
## Problem
The scheduled time of an `adBreak` event was not mapped to the magic time.

## Fix
Map scheduled time to magic time.