### PR TITLE
Send an END event when the source is unloaded

### DIFF
--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -679,6 +679,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     // reset all local attributes
     this.unregisterPlayerEvents();
     if (this.manager) {
+      this.manager.reportPlayerEvent(YSPlayerEvents.END);
       this.manager.shutdown();
       this.manager = null;
     }


### PR DESCRIPTION
Calling `unload()` during VPAID ad playback causes the Yospace SDK to get into an incorrect state. Future playback sessions still think they are in a VPAID ad.

We have found a workaround by sending both the `END` event and calling `shutdown()` on the Yospace SDK.

Previously we were only calling `shutdown()` when a source was unloaded.