### PR TITLE
fixed duplicate seek and seeked events 

### DIFF
--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -240,6 +240,8 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       const suppressedEventTypes = [
         this.player.exports.PlayerEvent.TimeChanged,
         this.player.exports.PlayerEvent.Paused,
+        this.player.exports.PlayerEvent.Seeked,
+        this.player.exports.PlayerEvent.Seek,
 
         // Suppress all ad events
         this.player.exports.PlayerEvent.AdBreakFinished,


### PR DESCRIPTION
 - fixed duplicate seek and seeked events by adding the events to the suppressedEventTypes.

@stonko1994 was there any reason why these were left off in the first place? I cant seem to think of one. For most seek commands, we fire the event inside of the BitmovinYospacePlayer so there is no need to pass the seek and seeked callbacks down to the underlying bitmovin player engine. This is where the duplicate events were coming from