### PR TITLE
Not interacting with TrueX ad causes exception in AdSkipped event

### DIFF
--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1055,7 +1055,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.fireEvent<AdEvent>({
       timestamp: Date.now(),
       type: this.player.exports.PlayerEvent.AdSkipped,
-      ad: AdTranslator.mapYsAdvert(this.getCurrentAd()),
+      ad: AdTranslator.mapYsAdvert(this.lastVPaidAd),
     });
   };
 


### PR DESCRIPTION
Fixes issue: https://github.com/TurnerOpenPlatform/tub-lib/issues/388

- When sending the adskipped event, we should reference the `lastVpaidAd`, not the `currentAd`
- This fixes an exception that is generated during truex ads that are not interacted with