### PR TITLE
Fire new TruexAdBreakFinished event

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -432,14 +432,15 @@
     yospacePlayer.on('truexadfree', function(event) {
       truexAdFree = true
       console.debug(event);
-
-      setTimeout(()=> {
-        const seekPosition = adBreakState.ab.scheduleTime + 1
-        console.warn('TrueXAdFree Seeking to ' + seekPosition);
-        yospacePlayer.forceSeek(seekPosition)
-      }, 500)
-
     })
+
+    yospacePlayer.on('truexadbreakfinished', function(event) {
+      if (truexAdFree) {
+        const seekPosition = adBreakState.ab.scheduleTime + 1
+        console.warn('TrueXAdBreakFinished Seeking to ' + seekPosition);
+        yospacePlayer.forceSeek(seekPosition)
+      }
+    });
 
     yospacePlayer.on('adstarted', function(event) {
       console.debug('Ad Started' + JSON.stringify(event));

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -130,6 +130,7 @@ export enum YospacePlayerEvent {
   YospaceError = 'yospaceerror',
   PolicyError = 'policyerror',
   TruexAdFree = 'truexadfree',
+  TruexAdBreakFinished = 'truexadbreakfinished',
 }
 
 export enum YospaceErrorCode {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1172,6 +1172,15 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   };
 
   private onVpaidAdBreakFinished = (event: AdBreakEvent) => {
+    const currentAd = this.lastVPaidAd;
+
+    if (currentAd.advert.AdSystem === 'trueX') {
+      this.fireEvent({
+        timestamp: Date.now(),
+        type: YospacePlayerEvent.TruexAdBreakFinished,
+      });
+    }
+
     this.lastVPaidAd = null;
     this.truexAdFree = undefined;
   };


### PR DESCRIPTION
Firing a new `TruexAdBreakFinished` event, which will be used in Tub to seek to the correct position following a Truex break, instead of listening to the `TruexAdFree` event.