### PR TITLE
Enable YSParseUtils.NAMESPACES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Develop
 ## Added
-- Exposed new `YSAdBreak.position` property 
+- Exposed new `YSAdBreak.position` property
+
+## Changed
+- Set `YSParseUtils.NAMESPACES = true` to resolve an XML parsing issue on Smart TVs
 
 ## [1.2.8]
 ## Added

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -259,6 +259,8 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
         properties.STRICT_BREAKS = true;
       }
 
+      YSParseUtils.NAMESPACES = true;
+
       switch (source.assetType) {
         case YospaceAssetType.LINEAR:
           this.manager = YSSessionManager.createForLive(url, properties, onInitComplete);

--- a/src/ts/Yospace.d.ts
+++ b/src/ts/Yospace.d.ts
@@ -201,3 +201,7 @@ declare class VASTInteractive {
 
   src: string;
 }
+
+declare class YSParseUtils {
+  static NAMESPACES: boolean
+}


### PR DESCRIPTION
Per recommendation from Tony at Yospace, setting this value to true resolves an issue with XML parsing on Smart TVs.