### PR TITLE
Fix destroy method which was causing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Set `YSParseUtils.NAMESPACES = true` to resolve an XML parsing issue on Smart TVs
 - Upgrade `bitmovin-player` to version `8.35.0`
 
+## Fixed
+- Remove code to destroy both players as it was causing an exception and not needed. 
+
 ## [1.2.8]
 ## Added
 - Expose `YospaceAdBreak` and `YospaceAdBreakEvent` interfaces for use by integrators. 

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -241,11 +241,7 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   }
 
   destroy(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      this.bitmovinPlayer.destroy().then(() => {
-        this.bitmovinYospacePlayer.destroy().then(resolve).catch(reject);
-      });
-    });
+    return this.player.destroy();
   }
 
   // Default methods propagated to this.player


### PR DESCRIPTION
Remove legacy code which was destroying both instantiated players. We have since changed the method of instantiating players so this is no longer needed and it was resulting in an exception and unfulfilled promise. 