### PR TITLE
Release 1.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Develop
+## [1.2.12]
 ## Changed
 - Update `bitmovin-player` to version `8.37.1`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Yospace integration for the Bitmovin Player",
   "main": "./dist/js/bitmovin-player-yospace.js",
   "types": "./dist/js/bitmovin-player-yospace.d.ts",

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -630,7 +630,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
           + this.yospaceConfig.liveVpaidDurationAdjustment + ' - ' + replaceContentDuration);
       }
 
-      // If we are scheduling a VPAID for Truex, do not add a replaceContentDuration, 
+      // If we are scheduling a VPAID for Truex, do not add a replaceContentDuration,
       // as we seek over the ad break when appropriate in TUB
       if (!this.isLive() && isTruexAd) {
         replaceContentDuration = 0;


### PR DESCRIPTION
## Changed
- Update `bitmovin-player` to version `8.37.1`.

## Fixed
- Suppress Yospace Analytics before sending the Pause event at the start of a VPAID, per Yospace recommendation.
- Remove `-2` adjustment to `replaceContentDuration` for Truex VPAID ads, as seeking logic is handled in TUB. 