### PR TITLE
LastVpaid Type error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# Develop
+## Fixed
+- Type error in `onVpaidAdBreakStarted` event handler. 
+
 ## [1.2.15]
 ## Added
 - Emit `metadataParsed` and `metadata` events for generated EMSG/ID3 tags in the DateRangeEmitter.

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1267,7 +1267,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
     const currentAd = this.getCurrentAd();
     const currentBreak = currentAd.adBreak;
-    Logger.log('[BitmovinYospacePlayer] tracking VPAID event ' + event + ' id=' + this.lastVPaidAd.getMediaID());
+    Logger.log('[BitmovinYospacePlayer] tracking VPAID event ' + event + ' id=' + currentAd.getMediaID());
     currentAd.getInteractiveUnit().track(
       event,
       this.player.getCurrentTime(), // The VPAID ad needs to implement the VPAID API otherwise we will report 0 here


### PR DESCRIPTION
`lastVPaidAd` is incorrectly accessed in a log message before it has been instantiated.