### PR TITLE
Remove AdClicked Suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 # develop
 ## Changed
 - Update `bitmovin-player` to version `8.50.0`
+- Remove suppression of `AdClicked` event so it can be consumed by integrators for VPAID ads. 
 
 # [1.2.17]
 ## Changed

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -312,7 +312,6 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
         // Suppress all ad events
         this.player.exports.PlayerEvent.AdBreakFinished,
         this.player.exports.PlayerEvent.AdBreakStarted,
-        this.player.exports.PlayerEvent.AdClicked,
         this.player.exports.PlayerEvent.AdError,
         this.player.exports.PlayerEvent.AdFinished,
         this.player.exports.PlayerEvent.AdLinearityChanged,


### PR DESCRIPTION
The `AdClicked` event was being suppressed for VPAID ads which meant that other integrations like IAS for example, would be unable to consume it. 