### PR TITLE
MECBM: VPAID Quartile and Rendering Fixes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -147,7 +147,7 @@ gulp.task('serve', function() {
             server: {
                 baseDir: [paths.target.html],
                 index: 'index.html',
-                https: true,
+                https: false,
                 routes: {
                     '/yospace': './yospace',
                     '/js': './dist/js/'

--- a/src/index.html
+++ b/src/index.html
@@ -90,6 +90,26 @@
                 </div>
             </div>
         </div>
+
+        <div class='row'>
+          <div class='col'>
+              <div class='input-group mb-3'>
+                  <select class='custom-select col-12' id='tearsheet-override'>
+                      <option value='0' selected>Override Ad Tearsheet</option>
+                      <option value="55085793" data-id="141403_CNN_Fuji_VPAID_30s_307518956_6.30">55085793 - Fuji Film 30s</option>
+                      <option value="54510215" data-id="139334_CNN_Invesco_Markets_VPAID_15s_306893272_6.28.21">54510215 - Invesco Limited 15s</option>
+                      <option value="54510215" data-id="139334_CNN_Invesco_Markets_VPAID_15s_306893272_6.28.21">54510215 - Invesco Limited 30s</option>
+                      <option value="52125737" data-id="138227_CNN_IBM CA Cash_Desktop_15s_VPAID_289436970_NEW_2.25.21">52125737 - IBM Corp 15s</option>
+                      <option value="54476788" data-id="141744_CNN_Farmers_Q3_15s_VPAID_2371065_6.24.21">54476788 - Farmers 15s</option>
+                      <option value="54476788" data-id="141744_CNN_Farmers_Q3_30s_VPAID_2371066_6.24.21">54476788 - Farmers 30s</option>
+                      <option value="50323493" data-id="138527_CNN_ROS_Tobacco_Free_Kids_293007205_VPAID_30s_1.7">50323493 - Tobacco Free Kids 30s</option>
+                      <option value="49929643" data-id="138222_CNN_IBM CA_VPAID_289542595_15s_NEW_2.25.21">49929643 - IBM Corp-2 30s</option>
+                      <option value="55085793" data-id="141403_CNN_Fuji_Vpaid_with_mp4_30_307581174_7.1">55085793 - Fuji Film-2 30s</option>
+                      <option value="51153356" data-id="141403_CNN_Fuji_Vpaid_with_mp4_30_307581174_7.1">51153356 - Association of AM Railroads 15s</option>
+                  </select>
+              </div>
+          </div>
+        </div>
     </div>
     <div class="content">
         <div class="player-wrapper">
@@ -186,6 +206,16 @@
     return JSON.parse(JSON.stringify(obj))
   }
 
+  function overrideSourceAdKvps(source) {
+    var overrideEl = document.getElementById('tearsheet-override')
+    if (overrideEl.value === '0') {
+      return source
+    }
+
+    source.hls = source.hls + '&tearsheet=' + overrideEl.value
+    return source
+  }
+
   vodButton.on('click', function() {
     vodButton.button('toggle');
     deselectCustomLoadButton();
@@ -199,6 +229,8 @@
     deselectCustomLoadButton();
 
     yospacePlayer.unload();
+
+    source = overrideSourceAdKvps(vodPreVpaidSource)
     yospacePlayer.load(vodPreVpaidSource);
   });
 
@@ -413,6 +445,7 @@
     disableVpaidRenderer: !vpaid,
     disableAggressiveVpaidPreroll: !aggressiveVpaid,
     liveVpaidDurationAdjustment: 2,
+    vodVpaidDurationAdjustment: 0,
     disableStrictBreaks: false,
     disableServiceWorker: false,
   };
@@ -484,6 +517,10 @@
     yospacePlayer.on('moduleready', function(event) {
       console.log('[BYP] moduleready ', cloneDeepSimple(event));
     })
+
+      yospacePlayer.on('aderror', function(event) {
+          console.error('[BYP] AdError ', cloneDeepSimple(event));
+      })
 
     yospacePlayer.on('playing', function(event) {
       console.log('[BYP] playing ', cloneDeepSimple(event))

--- a/src/ts/VastHelper.ts
+++ b/src/ts/VastHelper.ts
@@ -6,6 +6,13 @@ import { CompanionAdResource, CompanionAdType, YospaceCompanionAd } from './Bitm
 import { Logger } from './Logger';
 import stringify from 'fast-safe-stringify';
 
+interface UriBuilderData {
+  ad: VASTAd,
+  removeTrackingBeacons: boolean,
+  removeImpressions: boolean,
+  removeUnsupportedExtensions: boolean,
+}
+
 export class VastHelper {
 
   static getExtensions(ad: VASTAd): any[] {
@@ -14,8 +21,9 @@ export class VastHelper {
     });
   }
 
-  static buildDataUriWithoutTracking(ad: VASTAd): string {
+  static buildDataUriWithoutTracking(data: UriBuilderData): string {
     // build a valid VAST xml data uri to schedule only the current vpaid ad
+    const { ad, removeImpressions, removeTrackingBeacons, removeUnsupportedExtensions } = data
     const vastXML = ad.vastXML;
 
     // NOTE: Previously the only XML nodes from the VAST we were removing were
@@ -27,11 +35,27 @@ export class VastHelper {
     // able to fire the Default Impressions, and because of that, duplicate impressions
     // were firing in some cases. It is now assumed that Yospace will handling
     // all beaconing, and Bitmovin will just render the physical VPAID.
-    const beaconingEvents = ['TrackingEvents', 'Tracking', 'Impression'];
-    this.removeXmlNodes(beaconingEvents, vastXML);
+    if (removeTrackingBeacons) {
+      const beaconingEvents = ['TrackingEvents', 'Tracking'];
+      this.removeXmlNodes(beaconingEvents, vastXML);
+    }
+
+    if (removeImpressions) {
+      const impressions = ['Impression'];
+      this.removeXmlNodes(impressions, vastXML);
+    }
+
+    // It appears in some cases the Bitmovin ad module fails to parse specific
+    // Extensions. This is related to recursive Extensions:
+    // https://jiraprod.turner.com/browse/MECBM-663
+    if (removeUnsupportedExtensions) {
+      const unsupportedExtensions = ['AVID'];
+      this.removeXmlNodes(unsupportedExtensions, vastXML);
+    }
 
     const vastVersion = vastXML.parentElement.getAttribute('version');
     const vastXMLString = '<VAST version="' + vastVersion + '">' + vastXML.outerHTML + '</VAST>';
+
     return 'data:text/xml,' + encodeURIComponent(vastXMLString);
   }
 


### PR DESCRIPTION
## Overview

This PR add fixes for the following issues:
* Failed VPAID rendering
* Additional quartile beacons at the end of ad playback.

Closes:
* [MECBM-661](https://jiraprod.turner.com/browse/MECBM-661)
* [MECBM-662](https://jiraprod.turner.com/browse/MECBM-662)

## Testing

* Ensure you're using Node v10 or v11 for Gulp to run
* Ensure you also have access to the [TUB Lib repo and can copy the Yospace Client SDK](https://github.com/TurnerOpenPlatform/tub-lib/blob/develop/web/scripts/yo-ad-management.min.js) JS into the local `yospace` directory in this repo
* `npm install && npm start` should open a browser window
* Run the demo with the following query parameters (https://localhost:9000/?aggressiveVpaid=true&vpaid=true):
  * `aggressiveVpaid=true` will enable the aggressive pre-rendering approach (which is enabled by default)
  * `vpaid=true` is the previous flag which allows for toggling VPAID on and off as a whole
* Select the `VOD Preroll VPAID` asset, and one of the `Tearsheet Overrides`:
  * Observe under the network traffic the following beacons fire without duplicates, for the `bea4` freewheel endpoint
    * `slotimpression` 
    * `defaultimpression`
    * `firstquartile`
    * `midpoint`
    * `thirquartile`
    * `complete`
* Select the `VOD Midroll VPAID` asset, and perform the same validation as above, seeking into the VOD `3:20` into playback which will trigger a Midroll ad break around `3:30`.
* You should also no longer see issues when attempting to playback the Fuji film ad