### PR TITLE
Queue timed metadata

### DIFF
--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1103,8 +1103,8 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.player.off(this.player.exports.PlayerEvent.StallStarted, this.onStallStarted);
     this.player.off(this.player.exports.PlayerEvent.StallEnded, this.onStallEnded);
 
-    this.player.on(this.player.exports.PlayerEvent.Muted, this.onMuted);
-    this.player.on(this.player.exports.PlayerEvent.Unmuted, this.onUnmuted);
+    this.player.off(this.player.exports.PlayerEvent.Muted, this.onMuted);
+    this.player.off(this.player.exports.PlayerEvent.Unmuted, this.onUnmuted);
 
     // To support ads in live streams we need to track metadata events
     this.player.off(this.player.exports.PlayerEvent.Metadata, this.onMetaData);


### PR DESCRIPTION
[Reference](https://eyevinn.slack.com/archives/C02QK0V2TLH/p1676543975850339)

There is some uncertainty around if `PlayerEvent.Metadata` is always triggered in correct sequential order by BM Player, since a customer and Yospace has reported TMD (TimedMetaData) being reported out of order under certain network conditions. See Yospace ticket linked in Reference above.

The BM Player should emit metadata events sequentially. According to @dweinber (see linked reference):

> Metadata is triggered [from BM Player] at the time the metadata should happen, as there's usually a time associated with each.

The current Yospace Integration listens to `PlayerEvent.Metadata` and pushes the metadata directly to the Yospace session, without doing any validation on the sequence or timing. To me, that makes it sound like the above quote isn't necessarily always true. The integration uses that event as the "source of truth" for metadata timing, and Yospace claims metadata is sometimes passed to the session out of order under severe network conditions.

This PR is primarily for debugging together with the customer. It creates a metadata cache by queuing events and not feeding them to the SDK until a playhead update occurs. The code keeps track of the largest playhead at which a TMD has been reported, if a TMD with a smaller playhead ever arrives it will log the message `MDD: BAD ORDER!`. That message indicates that the BM Player has given the Yospace Integration a metadata event that should have triggered before the previous metadata event.