### PR TITLE
Fix/remove npm engine specifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Removed node "16.15.1" requirement from npm package.
+
 ## 2.3.0 - 2023-05-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Removed node "16.15.1" requirement from npm package.
+## Removed
+
+- Node "16.15.1" engines requirement from npm package.
 
 ## 2.3.0 - 2023-05-02
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
   },
   "author": "Bitmovin",
   "license": "MIT",
-  "engines": {
-    "node": "16.15.1"
-  },
   "dependencies": {
     "@yospace/admanagement-sdk": "3.6.0",
     "bitmovin-player": "^8.114.0",


### PR DESCRIPTION
The `package.json` includes an "engines" field declaring a requirement for node 16.15.1.

If you start an empty project with the following package.json:
```
{
  "name": "testproj",
  "version": "1.0.0",
  "dependencies": {
    "@bitmovin/player-integration-yospace": "^2.3.0"
  }
}
```

running node 18, you will receive the following warning:
```
lkaalim@N1003643 testproj % npm i @bitmovin/player-integration-yospace                                           
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@bitmovin/player-integration-yospace@2.3.0',
npm WARN EBADENGINE   required: { node: '16.15.1' },
npm WARN EBADENGINE   current: { node: 'v16.14.0', npm: '9.8.1' }
npm WARN EBADENGINE }
```

As the `@bitmovin/player-integration-yospace` package is mostly intended to run on browsers and video-playing-environments, theres no actual requirement for consumers of this package to have a specific version of node. In fact, if you have _any_ version of node apart from 16.15.1 _specifically_, npm will report that warning.

If using `yarn`, the error is more fatal:
```
lkaalim@N1003643 testproj % yarn
yarn install v1.22.21
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error @bitmovin/player-integration-yospace@2.3.0: The engine "node" is incompatible with this module. Expected version "16.15.1". Got "18.19.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

When installing this own package for development purposes and during test runs in CI, you also see the same warning as this project itself uses node 18 as defined in it's `.nvmrc`:
```
v18.13.0
```

The engines field isn't relevant for this project, as the nvmrc file determine what version of node someone developing this package should use, and the version of node that a consumer happens to use to install the project has no relevance on the actual runtime expected from this package.

If there is somehow a requirement for clients to use specific versions of node, the engine field should be updated to be either:
  - `"node": "~16.15.1"` (for node 16 specifically)
  - `"node": ">16.15.1"` (for node 16 and above)