### PR TITLE
Extend API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Event loop on pre-roll ad end
 
+### Changed
+
+- added mode argument to getCurrentTime to enable fetching absolute time
+- added mode argument to getDuration to enable fetching absolute duration
+
 ## 2.3.1 - 2024-02-14
 
 ### Removed
@@ -51,7 +56,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `shownToUser` method to Companion Ads, which should be fired when the ad is shown to the user
 - `hiddenFromUser` method to Companion Ads, which should be fired when the ad is hidden from the user
 - `UNKNOWN_FORMAT` error (code `1011`)
-- `YospaceConfiguration.debugYospaceSdk` to enable debug logs of the Yospace SDK without enabling logs for the `BitmovinYospacePlayer` (helpful for Yospace validation)
+- `YospaceConfiguration.debugYospaceSdk` to enable debug logs of the Yospace SDK without enabling logs for
+  the `BitmovinYospacePlayer` (helpful for Yospace validation)
 - Support for tracking muted/unmuted changes
 
 ### Changed
@@ -125,7 +131,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Use standalone Bitmovin Analytics Adapter for flexibility. And move initialization to `load()` to dynamically attach to the correct player based on source.
+- Use standalone Bitmovin Analytics Adapter for flexibility. And move initialization to `load()` to dynamically attach
+  to the correct player based on source.
   - Note: This change required updating to TypeScript version 3.
 
 ## 1.2.20-2 - 2021-07-28
@@ -149,13 +156,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Remove the [arrayAccessForm](https://github.com/x2js/x2js/blob/development/x2js.d.ts#L116), config option from `X2JS` initialization for parsing VAST Extensions. This was causing unpredictable arrays for the `Extension.CreativeParameters` property. Without the option, it consistently returns an object when there is only one `CreativeParameter` property.
+- Remove the [arrayAccessForm](https://github.com/x2js/x2js/blob/development/x2js.d.ts#L116), config option from `X2JS`
+  initialization for parsing VAST Extensions. This was causing unpredictable arrays for
+  the `Extension.CreativeParameters` property. Without the option, it consistently returns an object when there is only
+  one `CreativeParameter` property.
 
 ## 1.2.19 - 2021-01-20
 
 ### Fixed
 
-- Added a temporary fix for a bug on Safari mobile that results in duplicate ad events from Yospace, as a result of incorrect Position updates reported to the YS SDK.
+- Added a temporary fix for a bug on Safari mobile that results in duplicate ad events from Yospace, as a result of
+  incorrect Position updates reported to the YS SDK.
 
 ### Added
 
@@ -263,7 +274,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- When the `disableServiceWorker` flag is set to true, don't make calls to `navigator.serviceWorker.getRegistrations()`. This was causing issues on Tizen devices.
+- When the `disableServiceWorker` flag is set to true, don't make calls to `navigator.serviceWorker.getRegistrations()`.
+  This was causing issues on Tizen devices.
 
 ## 1.2.5 - 2020-04-15
 
@@ -287,7 +299,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Fire `TruexAdFree` in the `adBreakFinished` listener instead of `adFinished`, as the stream isn't fully reloaded for seeking after `adFinished`
+- Fire `TruexAdFree` in the `adBreakFinished` listener instead of `adFinished`, as the stream isn't fully reloaded for
+  seeking after `adFinished`
 - Update Bitmovin Web SDK to 08.31.0
 - `player.isLive()` returns false when in a VPAID, so store `isLiveStream` in a variable upon playing the stream.
 
@@ -301,7 +314,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Always fire the `TrueXAdFree` event
-- Reduce the replaceContentDuration by 2 seconds in order to allow the player to properly skip the VPAID / TrueX ad if needed
+- Reduce the replaceContentDuration by 2 seconds in order to allow the player to properly skip the VPAID / TrueX ad if
+  needed
 - Updated Bitmovin Web SDK to 8.30.0
 - Fire a new `TruexAdBreakFinished` event
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- added mode argument to getCurrentTime to enable fetching absolute time
+- `mode` argument to `getCurrentTime` to enable fetching absolute time including ad durations
 - added mode argument to getDuration to enable fetching absolute duration
 
 ## 2.3.1 - 2024-02-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `mode` argument to `getCurrentTime` to enable fetching absolute time including ad durations
-- added mode argument to getDuration to enable fetching absolute duration
+- `mode` argument to `getDuration` to enable fetching absolute duration including ad durations
 
 ## 2.3.1 - 2024-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Event loop on pre-roll ad end
 
-### Changed
+### Added
 
 - added mode argument to getCurrentTime to enable fetching absolute time
 - added mode argument to getDuration to enable fetching absolute duration

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@yospace/admanagement-sdk": "3.6.0",
-        "bitmovin-player": "^8.114.0",
+        "bitmovin-player": "^8.157.0",
         "fast-safe-stringify": "^2.0.7",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0"
@@ -1217,9 +1217,9 @@
       "dev": true
     },
     "node_modules/bitmovin-player": {
-      "version": "8.114.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.114.0.tgz",
-      "integrity": "sha512-wgrcKd7YHQp0KwAF4OeIxYxlE7TaA9BgPfAI4vcdMnchKyEibK1PHfsa8DM/BWsJ+SmMAJU/lWG3O3Xb8ZkYTA=="
+      "version": "8.157.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.157.0.tgz",
+      "integrity": "sha512-+iCw2gJBQDVCcukYXwtBa7u7VMb40POzj1VB6Nq+/wNP91HfL8SwsUuX0KigyScSam/rY1gxvnllIKQlqq80Ag=="
     },
     "node_modules/bitmovin-player-ui": {
       "version": "3.37.0",
@@ -6445,9 +6445,9 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.114.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.114.0.tgz",
-      "integrity": "sha512-wgrcKd7YHQp0KwAF4OeIxYxlE7TaA9BgPfAI4vcdMnchKyEibK1PHfsa8DM/BWsJ+SmMAJU/lWG3O3Xb8ZkYTA=="
+      "version": "8.157.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.157.0.tgz",
+      "integrity": "sha512-+iCw2gJBQDVCcukYXwtBa7u7VMb40POzj1VB6Nq+/wNP91HfL8SwsUuX0KigyScSam/rY1gxvnllIKQlqq80Ag=="
     },
     "bitmovin-player-ui": {
       "version": "3.37.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@yospace/admanagement-sdk": "3.6.0",
-    "bitmovin-player": "^8.114.0",
+    "bitmovin-player": "^8.157.0",
     "fast-safe-stringify": "^2.0.7",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0"

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -1,4 +1,5 @@
 import {
+  AdaptationAPI,
   AudioQuality,
   AudioTrack,
   DownloadedAudioData,
@@ -23,6 +24,7 @@ import {
   SupportedTechnologyMode,
   Technology,
   Thumbnail,
+  TimeMode,
   TimeRange,
   VideoQuality,
   ViewMode,
@@ -334,16 +336,8 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.getContainer();
   }
 
-  getCurrentTime(): number {
-    return this.player.getCurrentTime();
-  }
-
-  getCurrentAdBreakDuration(): number {
-    return this.player.getCurrentAdBreakDuration();
-  }
-
-  getCurrentTimeWithAds(): number {
-    return this.player.getCurrentTimeWithAds();
+  getCurrentTime(mode?: TimeMode): number {
+    return this.player.getCurrentTime(mode);
   }
 
   getDownloadedAudioData(): DownloadedAudioData {
@@ -358,12 +352,12 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.getDroppedVideoFrames();
   }
 
-  getDuration(): number {
-    return this.player.getDuration();
+  getDuration(mode?: TimeMode): number {
+    return this.player.getDuration(mode);
   }
 
-  getDurationWithAds(): number {
-    return this.player.getDurationWithAds();
+  get adaptation(): AdaptationAPI {
+    return this.player.adaptation;
   }
 
   getManifest(): string {

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -338,6 +338,10 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.getCurrentTime();
   }
 
+  getCurrentAdBreakDuration(): number {
+    return this.player.getCurrentAdBreakDuration();
+  }
+
   getCurrentTimeWithAds(): number {
     return this.player.getCurrentTimeWithAds();
   }

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -338,6 +338,10 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.getCurrentTime();
   }
 
+  getCurrentTimeWithAds(): number {
+    return this.player.getCurrentTimeWithAds();
+  }
+
   getDownloadedAudioData(): DownloadedAudioData {
     return this.player.getDownloadedAudioData();
   }
@@ -352,6 +356,10 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
   getDuration(): number {
     return this.player.getDuration();
+  }
+
+  getDurationWithAds(): number {
+    return this.player.getDurationWithAds();
   }
 
   getManifest(): string {

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -50,8 +50,22 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
 
   getCurrentPlayerType(): YospacePlayerType;
 
+  /*
+   * By default, the method returns the current content position, discarding stitched ad durations. If an ad
+   * is playing, the position inside of the ad will instead be returned.
+   *
+   * if TimeMode.AbsoluteTime is provided as an argument to the method, it will instead always return the current time
+   * including stitched ad durations.
+   */
   getCurrentTime(mode?: TimeMode): number;
 
+  /*
+   * By default, the method returns the current content duration, discarding stitched ad durations. If an ad
+   * is playing, the duration of the ad will instead be returned.
+   *
+   * if TimeMode.AbsoluteTime is provided as an argument to the method, it will instead always return the duration
+   * including stitched ad durations.
+   */
   getDuration(mode?: TimeMode): number;
 
   forceSeek(time: number, issuer?: string): boolean;

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -8,6 +8,7 @@ import {
   PlayerExports,
   SourceConfig,
 } from 'bitmovin-player';
+import { TimeMode } from 'bitmovin-player/modules/bitmovinplayer-core';
 
 // Enums
 
@@ -49,11 +50,9 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
 
   getCurrentPlayerType(): YospacePlayerType;
 
-  getCurrentAdBreakDuration(): number;
+  getCurrentTime(mode?: TimeMode): number;
 
-  getCurrentTimeWithAds(): number;
-
-  getDurationWithAds(): number;
+  getDuration(mode?: TimeMode): number;
 
   forceSeek(time: number, issuer?: string): boolean;
 }

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -49,6 +49,8 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
 
   getCurrentPlayerType(): YospacePlayerType;
 
+  getCurrentAdBreakDuration(): number;
+
   getCurrentTimeWithAds(): number;
 
   getDurationWithAds(): number;

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -49,6 +49,10 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
 
   getCurrentPlayerType(): YospacePlayerType;
 
+  getCurrentTimeWithAds(): number;
+
+  getDurationWithAds(): number;
+
   forceSeek(time: number, issuer?: string): boolean;
 }
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -36,6 +36,7 @@ import {
   SeekEvent,
   SourceConfig,
   TimeChangedEvent,
+  TimeMode,
   TimeRange,
   UserInteractionEvent,
 } from 'bitmovin-player/modules/bitmovinplayer-core';
@@ -406,7 +407,11 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.seek(magicSeekTarget, issuer);
   }
 
-  getCurrentTime(): number {
+  getCurrentTime(mode?: TimeMode): number {
+    if (mode === TimeMode.AbsoluteTime) {
+      return this.player.getCurrentTime();
+    }
+
     if (this.isAdActive()) {
       // return currentTime in AdBreak
       const currentAdPosition = this.player.getCurrentTime();
@@ -416,12 +421,12 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.toMagicTime(this.player.getCurrentTime());
   }
 
-  getCurrentTimeWithAds(): number {
-    return this.player.getCurrentTime();
-  }
-
-  getDuration(): number {
+  getDuration(mode?: TimeMode): number {
     if (!this.session) return 0;
+
+    if (mode === TimeMode.AbsoluteTime) {
+      return this.player.getDuration();
+    }
 
     if (this.isAdActive()) {
       return this.getCurrentAdDuration();
@@ -434,18 +439,6 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return toSeconds(
       (this.session as SessionVOD).getContentPositionForPlayhead(toMilliseconds(this.player.getDuration()))
     );
-  }
-
-  getCurrentAdBreakDuration(): number {
-    if (this.isAdActive()) {
-      return this.getAdBreakDuration(this.getCurrentAdBreak());
-    }
-
-    return 0;
-  }
-
-  getDurationWithAds(): number {
-    return this.player.getDuration();
   }
 
   /**
@@ -785,10 +778,6 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
   private getAdDuration(ad: Advert): number {
     return toSeconds(ad.getDuration());
-  }
-
-  private getAdBreakDuration(adbreak: AdBreak): number {
-    return toSeconds(adbreak.getDuration());
   }
 
   private getAdStartTime(ad: Advert): number {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -95,10 +95,6 @@ interface StreamPart {
   adBreak?: AdBreak;
 }
 
-interface YospaceTimeChangedEvent extends TimeChangedEvent {
-  timeWithAds: number;
-}
-
 // TODO: remove this when it's available in the Player
 export interface YospaceLinearAd extends LinearAd {
   extensions: VastAdExtension[];
@@ -1157,11 +1153,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     }
 
     // fire magic time-changed event
-    this.fireEvent<YospaceTimeChangedEvent>({
+    this.fireEvent<TimeChangedEvent>({
       timestamp: Date.now(),
       type: this.player.exports.PlayerEvent.TimeChanged,
       time: this.getCurrentTime(),
-      timeWithAds: this.getCurrentTimeWithAds(),
     });
   };
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -95,6 +95,10 @@ interface StreamPart {
   adBreak?: AdBreak;
 }
 
+interface YospaceTimeChangedEvent extends TimeChangedEvent {
+  timeWithAds: number;
+}
+
 // TODO: remove this when it's available in the Player
 export interface YospaceLinearAd extends LinearAd {
   extensions: VastAdExtension[];
@@ -416,6 +420,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.toMagicTime(this.player.getCurrentTime());
   }
 
+  getCurrentTimeWithAds(): number {
+    return this.player.getCurrentTime();
+  }
+
   getDuration(): number {
     if (!this.session) return 0;
 
@@ -430,6 +438,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return toSeconds(
       (this.session as SessionVOD).getContentPositionForPlayhead(toMilliseconds(this.player.getDuration()))
     );
+  }
+
+  getDurationWithAds(): number {
+    return this.player.getDuration();
   }
 
   /**
@@ -1133,10 +1145,11 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     }
 
     // fire magic time-changed event
-    this.fireEvent<TimeChangedEvent>({
+    this.fireEvent<YospaceTimeChangedEvent>({
       timestamp: Date.now(),
       type: this.player.exports.PlayerEvent.TimeChanged,
       time: this.getCurrentTime(),
+      timeWithAds: this.getCurrentTimeWithAds(),
     });
   };
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -440,6 +440,14 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     );
   }
 
+  getCurrentAdBreakDuration(): number {
+    if (this.isAdActive()) {
+      return this.getAdBreakDuration(this.getCurrentAdBreak());
+    }
+
+    return 0;
+  }
+
   getDurationWithAds(): number {
     return this.player.getDuration();
   }
@@ -781,6 +789,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
   private getAdDuration(ad: Advert): number {
     return toSeconds(ad.getDuration());
+  }
+
+  private getAdBreakDuration(adbreak: AdBreak): number {
+    return toSeconds(adbreak.getDuration());
   }
 
   private getAdStartTime(ad: Advert): number {


### PR DESCRIPTION
Adds the following:

- Ability to fetch the current timestamp including stitched ad durations when viewing VODs. CAUTION: this timestamp may refer to different relative positions on each video start, depending on length of stitched ads
- Ability to fetch the duration including stitched ad durations when viewing VODs. CAUTION: this timestamp may refer to different relative positions on each video start, depending on length of stitched ads

to test, call:

```javascript
player.getCurrentTime(TimeMode.AbsoluteTime);
player.getDuration(TimeMode.AbsoluteTime);
```

If the player is currently playing an ad, by default, the methods would return the position within the ad and the duration of the ad respectively. If the `TimeMode.AbsoluteTime` parameter is added, the methods will instead return the absolute time, ignoring ongoing ads.