### PR TITLE
Ad Holiday Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Returns a boolean value indicating if the user is currently immune to ad breaks
   `isAdImmunityActive(): boolean;`
 
+  Immediately starts an ad immunity period, if ad immunity config exists. This method does nothing if ad immunity is already active.
+  `startAdImmunity(): void;`
+
   Immediately ends an ongoing ad immunity period, before it would naturally expire
   `endAdImmunity(): void;`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,51 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Event loop on pre-roll ad end
+- Bitmovin Player getting bundled into the YospaceBitmovinPlayer
+
 ### Added
 
 - `mode` argument to `getCurrentTime` to enable fetching absolute time including ad durations
 - `mode` argument to `getDuration` to enable fetching absolute duration including ad durations
 
+## 2.4.0
+
+### Added
+
+- ad immunity feature:
+
+  The user will become immune to ad breaks for a duration upon
+  fully watching an ad break.
+
+  Ad breaks played over or seeked past during immunity will be marked
+  as deactivated, making the user permanently immune to them.
+
+  setting duration to 0 disables the feature.
+
+  postrolls and ads with unknown positioning are excluded from ad immunity.
+
+  `setAdImmunityConfig(options: AdImmunityConfig): void;`
+
+  Returns the current ad immunity configuration.
+  duration 0 means the feature is disabled.
+  `getAdImmunityConfig(): AdImmunityConfig;`
+
+  Returns a boolean value indicating if the user is currently immune to ad breaks
+  `isAdImmunityActive(): boolean;`
+
+  Immediately ends an ongoing ad immunity period, before it would naturally expire
+  `endAdImmunity(): void;`
+
+- ad immunity events to `YospacePlayerEvent` enum
+- `getCurrentAdBreakDuration` method. It returns the full duration of the currently playing ad break.
+- methods to fetch current time and duration of a vod, including stitched ad duration: `getCurrentTimeWithAds` and `getDurationWithAds`.
+
 ### Fixed
 
-- Event loop on pre-roll ad end
-- Bitmovin Player getting bundled into the YospaceBitmovinPlayer
+- prevent multiple ad break finished events
 
 ## 2.3.1 - 2024-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `mode` argument to `getCurrentTime` to enable fetching absolute time including ad durations
 - `mode` argument to `getDuration` to enable fetching absolute duration including ad durations
-
-## 2.4.0
-
-### Added
-
 - ad immunity feature:
 
   The user will become immune to ad breaks for a duration upon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Ad breaks played over or seeked past during immunity will be marked
   as deactivated, making the user permanently immune to them.
 
-  setting duration to 0 disables the feature.
+  Post-roll ads and ads with unknown positioning are excluded from ad immunity.
 
-  postrolls and ads with unknown positioning are excluded from ad immunity.
+  By default, pre-rolls are also excluded, since the user needs to finish
+  an ad break to enter an ad immunity period.
 
   `setAdImmunityConfig(options: AdImmunityConfig): void;`
 
   Returns the current ad immunity configuration.
-  duration 0 means the feature is disabled.
+
   `getAdImmunityConfig(): AdImmunityConfig;`
 
   Returns a boolean value indicating if the user is currently immune to ad breaks
@@ -46,12 +47,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `endAdImmunity(): void;`
 
 - ad immunity events to `YospacePlayerEvent` enum
-- `getCurrentAdBreakDuration` method. It returns the full duration of the currently playing ad break.
-- methods to fetch current time and duration of a vod, including stitched ad duration: `getCurrentTimeWithAds` and `getDurationWithAds`.
-
-### Fixed
-
-- prevent multiple ad break finished events
 
 ## 2.3.1 - 2024-02-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "2.4.0-rc.0",
+  "version": "2.4.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitmovin/player-integration-yospace",
-      "version": "2.4.0-rc.0",
+      "version": "2.4.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@yospace/admanagement-sdk": "3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "2.4.0",
+  "version": "2.5.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitmovin/player-integration-yospace",
-      "version": "2.4.0",
+      "version": "2.5.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@yospace/admanagement-sdk": "3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "2.3.1",
+  "version": "2.4.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitmovin/player-integration-yospace",
-      "version": "2.3.1",
+      "version": "2.4.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@yospace/admanagement-sdk": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "2.4.0-rc.0",
+  "version": "2.4.0-rc.1",
   "description": "Yospace integration for the Bitmovin Player",
   "main": "./dist/js/bitmovin-player-yospace.js",
   "types": "./dist/js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "2.4.0",
+  "version": "2.5.0-rc.0",
   "description": "Yospace integration for the Bitmovin Player",
   "main": "./dist/js/bitmovin-player-yospace.js",
   "types": "./dist/js/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitmovin/player-integration-yospace",
-  "version": "2.3.1",
+  "version": "2.4.0-rc.0",
   "description": "Yospace integration for the Bitmovin Player",
   "main": "./dist/js/bitmovin-player-yospace.js",
   "types": "./dist/js/main.d.ts",

--- a/src/index.html
+++ b/src/index.html
@@ -577,7 +577,7 @@
           log('[BYP] Metadata Parsed: ', cloneDeepSimple(event));
         });
 
-        //        yospacePlayer.setPolicy(sampleYospacePlayerPolicy);
+        yospacePlayer.setPolicy(sampleYospacePlayerPolicy);
 
         yospacePlayer.on('segmentplayback', function (event) {
           if (event.mimeType === 'video/mp4') {

--- a/src/index.html
+++ b/src/index.html
@@ -575,7 +575,7 @@
           log('[BYP] Metadata Parsed: ', cloneDeepSimple(event));
         });
 
-        yospacePlayer.setPolicy(sampleYospacePlayerPolicy);
+        //        yospacePlayer.setPolicy(sampleYospacePlayerPolicy);
 
         yospacePlayer.on('segmentplayback', function (event) {
           if (event.mimeType === 'video/mp4') {

--- a/src/index.html
+++ b/src/index.html
@@ -533,6 +533,8 @@
           yospaceConfig
         );
 
+        // yospacePlayer.setAdImmunityConfig({ duration: 20 });
+
         var uiManager = new bitmovin.playerui.UIFactory.buildDefaultUI(yospacePlayer);
 
         yospacePlayer.on('sourceloaded', function (event) {

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -50,6 +50,7 @@ import {
   YospacePlayerType,
   YospacePolicyErrorCode,
   YospaceSourceConfig,
+  AdImmunityConfig,
 } from './BitmovinYospacePlayerAPI';
 import { Logger } from './Logger';
 import { BitmovinYospaceHelper } from './BitmovinYospaceHelper';
@@ -574,6 +575,22 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
   getAspectRatio(): number {
     return this.player.getAspectRatio();
+  }
+
+  getAdImmunityConfig() {
+    return this.player.getAdImmunityConfig();
+  }
+
+  isAdImmunityActive() {
+    return this.player.isAdImmunityActive();
+  }
+
+  endAdImmunity() {
+    this.player.endAdImmunity();
+  }
+
+  setAdImmunityConfig(options: AdImmunityConfig) {
+    this.player.setAdImmunityConfig(options);
   }
 
   readonly drm: DrmAPI;

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -585,6 +585,10 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.isAdImmunityActive();
   }
 
+  startAdImmunity() {
+    this.player.startAdImmunity();
+  }
+
   endAdImmunity() {
     this.player.endAdImmunity();
   }

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -96,6 +96,12 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
   isAdImmunityActive(): boolean;
 
   /**
+   * Immediately starts an ad immunity period, if ad immunity config exists. This method does nothing if ad immunity is already active.
+   * To refresh an ad immunity period, first call endAdImmunity followed by startAdImmunity.
+   */
+  startAdImmunity(): void;
+
+  /**
    * Immediately ends an ongoing ad immunity period, before it would naturally expire
    */
   endAdImmunity(): void;

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -264,7 +264,10 @@ export interface AdImmunityEndedEvent extends YospaceEventBase {
 /**
  * @description Ad Immunity Configuration Object
  * @property duration - a number indicating the duration of the ad immunity period. 0 disables the feature.
+ * @property adBreakCheckOffset - a number indicating how far ahead ad immunity should look for ad breaks
+ * to skip past, in order to mitigate ad frames being displayed before they have time to be seeked past.
  */
 export interface AdImmunityConfig {
   duration: number;
+  adBreakCheckOffset?: number;
 }

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -78,17 +78,15 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
    * Ad breaks played over or seeked past during immunity will be marked
    * as deactivated, making the user permanently immune to those breaks.
    *
-   * duration 0 disables the feature
+   * Post-rolls are excluded from ad immunity
    *
-   * postrolls are excluded from ad immunity
-   *
+   * Pre-roll ads are excluded from ad immunity as at least one ad break needs to be
+   * watched completely
    */
   setAdImmunityConfig(options: AdImmunityConfig): void;
 
   /**
    * Returns the current ad immunity configuration
-   *
-   * duration 0 means the feature is disabled
    */
   getAdImmunityConfig(): AdImmunityConfig;
 

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -71,7 +71,7 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
   forceSeek(time: number, issuer?: string): boolean;
 
   /**
-   * Provide a duration greater than 0 to enable the ad immunity feature.
+   * Provide a duration in seconds greater than 0 to enable the ad immunity feature.
    * The user will become immune to ad breaks for the duration upon
    * fully watching an ad break.
    *
@@ -79,6 +79,9 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
    * as deactivated, making the user permanently immune to those breaks.
    *
    * duration 0 disables the feature
+   *
+   * postrolls are excluded from ad immunity
+   *
    */
   setAdImmunityConfig(options: AdImmunityConfig): void;
 

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -84,6 +84,7 @@ export interface TruexConfiguration {
 export interface YospaceAdBreak extends AdBreak {
   duration: number;
   position?: YospaceAdBreakPosition;
+  active: boolean;
 }
 
 export interface YospaceAdBreakEvent extends PlayerEventBase {

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -263,6 +263,10 @@ export interface AdImmunityEndedEvent extends YospaceEventBase {
   type: YospacePlayerEvent.AdImmunityEnded;
 }
 
+/**
+ * @description Ad Immunity Configuration Object
+ * @property duration - a number indicating the duration of the ad immunity period. 0 disables the feature.
+ */
 export interface AdImmunityConfig {
   duration: number;
 }

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -251,7 +251,7 @@ export interface YospacePlayerEventCallback {
 
 export interface AdImmunityConfiguredEvent extends YospaceEventBase {
   type: YospacePlayerEvent.AdImmunityConfigured;
-  config: { duration: number };
+  config: AdImmunityConfig;
 }
 
 export interface AdImmunityStartedEvent extends YospaceEventBase {

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -165,6 +165,9 @@ export enum YospacePlayerEvent {
   PolicyError = 'policyerror',
   TruexAdFree = 'truexadfree',
   TruexAdBreakFinished = 'truexadbreakfinished',
+  AdImmunityConfigured = 'adimmunityconfigured',
+  AdImmunityStarted = 'adimmunitystarted',
+  AdImmunityEnded = 'adimmunityended',
 }
 
 export enum YospaceErrorCode {
@@ -212,4 +215,18 @@ export interface YospaceEventBase {
 
 export interface YospacePlayerEventCallback {
   (event: PlayerEventBase | YospaceEventBase): void;
+}
+
+export interface AdImmunityConfiguredEvent extends YospaceEventBase {
+  type: YospacePlayerEvent.AdImmunityConfigured;
+  config: { duration: number };
+}
+
+export interface AdImmunityStartedEvent extends YospaceEventBase {
+  type: YospacePlayerEvent.AdImmunityStarted;
+  duration: number;
+}
+
+export interface AdImmunityEndedEvent extends YospaceEventBase {
+  type: YospacePlayerEvent.AdImmunityEnded;
 }

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -75,6 +75,9 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
    * The user will become immune to ad breaks for the duration upon
    * fully watching an ad break.
    *
+   * Ad breaks played over or seeked past during immunity will be marked
+   * as deactivated, making the user permanently immune to those breaks.
+   *
    * duration 0 disables the feature
    */
   setAdImmunityConfig(options: AdImmunityConfig): void;

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -69,6 +69,32 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
   getDuration(mode?: TimeMode): number;
 
   forceSeek(time: number, issuer?: string): boolean;
+
+  /**
+   * Provide a duration greater than 0 to enable the ad immunity feature.
+   * The user will become immune to ad breaks for the duration upon
+   * fully watching an ad break.
+   *
+   * duration 0 disables the feature
+   */
+  setAdImmunityConfig(options: AdImmunityConfig): void;
+
+  /**
+   * Returns the current ad immunity configuration
+   *
+   * duration 0 means the feature is disabled
+   */
+  getAdImmunityConfig(): AdImmunityConfig;
+
+  /**
+   * Returns a boolean value indicating if the user is currently immune to ad breaks
+   */
+  isAdImmunityActive(): boolean;
+
+  /**
+   * Immediately ends an ongoing ad immunity period, before it would naturally expire
+   */
+  endAdImmunity(): void;
 }
 
 export interface YospaceSourceConfig extends SourceConfig {
@@ -229,4 +255,8 @@ export interface AdImmunityStartedEvent extends YospaceEventBase {
 
 export interface AdImmunityEndedEvent extends YospaceEventBase {
   type: YospacePlayerEvent.AdImmunityEnded;
+}
+
+export interface AdImmunityConfig {
+  duration: number;
 }

--- a/src/ts/BitmovinYospacePlayerPolicy.ts
+++ b/src/ts/BitmovinYospacePlayerPolicy.ts
@@ -1,5 +1,5 @@
 import { LinearAd } from 'bitmovin-player';
-import { BitmovinYospacePlayerAPI, BitmovinYospacePlayerPolicy } from './BitmovinYospacePlayerAPI';
+import { BitmovinYospacePlayerAPI, BitmovinYospacePlayerPolicy, YospaceAdBreak } from './BitmovinYospacePlayerAPI';
 
 export class DefaultBitmovinYospacePlayerPolicy implements BitmovinYospacePlayerPolicy {
   private player: BitmovinYospacePlayerAPI;
@@ -15,10 +15,11 @@ export class DefaultBitmovinYospacePlayerPolicy implements BitmovinYospacePlayer
 
   canSeekTo(seekTarget: number): number {
     const currentTime = this.player.getCurrentTime();
-    const adBreaks = this.player.ads.list();
+    // @ts-expect-error the BitmovinYospacePlayerAPI interface is not up to date
+    const adBreaks: YospaceAdBreak[] = this.player.ads.list();
 
     const skippedAdBreaks = adBreaks.filter((adBreak) => {
-      return adBreak.scheduleTime > currentTime && adBreak.scheduleTime < seekTarget;
+      return adBreak.active && adBreak.scheduleTime > currentTime && adBreak.scheduleTime < seekTarget;
     });
 
     if (skippedAdBreaks.length > 0) {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -402,14 +402,14 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     // this prevents the default player policy from redirecting
     // the seek target
     if (this.adImmune) {
-      const adBreaks: AdBreak[] = this.session.getAdBreaksByType(BreakType.LINEAR);
       const currentTime = this.player.getCurrentTime();
 
-      adBreaks.forEach((adBreak) => {
+      this.session.getAdBreaksByType(BreakType.LINEAR).forEach((adBreak) => {
         const breakStart = this.toMagicTime(toSeconds(adBreak.getStart()));
 
         // Check if break is being seeked past and deactivate it
         if (breakStart > currentTime && breakStart < time) {
+          Logger.log('[BitmovinYospacePlayer] Ad Immunity deactivated ad break during seek', adBreak);
           adBreak.setInactive();
         }
       });

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1243,9 +1243,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     // the offset is an attempt to prevent the first few frames of an ad
     // playing before the seek past the break has time to propagate
     const adBreakCheckOffset =
-      typeof this.adImmunityConfig.adBreakCheckOffset === 'number' ? this.adImmunityConfig.adBreakCheckOffset : 300;
+      typeof this.adImmunityConfig.adBreakCheckOffset === 'number' ? this.adImmunityConfig.adBreakCheckOffset : 0.3;
     const upcomingAdBreak: AdBreak | null = this.session.getAdBreakForPlayhead(
-      toMilliseconds(event.time) + adBreakCheckOffset
+      toMilliseconds(event.time) + toMilliseconds(adBreakCheckOffset)
     );
 
     // exclude postrolls and unknown break positions from ad immunity to prevent seek loops at end of video

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -623,7 +623,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
       this.adImmunityCountDown = window.setTimeout(() => {
         this.endAdImmunityPeriod();
-      }, this.adImmunityConfig.duration * 1000);
+      }, toMilliseconds(this.adImmunityConfig.duration));
 
       Logger.log('[BitmovinYospacePlayer] Ad Immunity Started, duration', this.adImmunityConfig.duration);
       this.handleYospaceEvent<AdImmunityStartedEvent>({
@@ -1227,7 +1227,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     // first few frames of an ad playing before the seek
     // past the break has time to propagate
     const adBreakCheckOffset = 500;
-    const upcomingAdBreak: AdBreak | null = this.session.getAdBreakForPlayhead(event.time * 1000 + adBreakCheckOffset);
+    const upcomingAdBreak: AdBreak | null = this.session.getAdBreakForPlayhead(
+      toMilliseconds(event.time) + adBreakCheckOffset
+    );
 
     // exclude postrolls and unknown break positions from ad immunity to prevent seek loops at end of video
     if (upcomingAdBreak?.getPosition() !== 'postroll' && upcomingAdBreak?.getPosition() !== 'unknown') {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1118,10 +1118,14 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       // need to stay in the SDK as there might be AdBreak Impressions and other beacons Yospace might need to trigger.
       // These ad breaks wouldn't be visible to the user and have a duration of `0`. Yospace's recommendation for us
       // is to filter out ads with duration = 0.
-      return this.session
-        .getAdBreaksByType(BreakType.LINEAR)
-        .map((adBreak: AdBreak) => this.mapAdBreak(adBreak))
-        .filter((adBreak: YospaceAdBreak) => adBreak.duration > 0);
+      return (
+        this.session
+          .getAdBreaksByType(BreakType.LINEAR)
+          .map((adBreak: AdBreak) => this.mapAdBreak(adBreak))
+          // filter out ad breaks deactivated by ad immunity
+          .filter((adBreak: YospaceAdBreak) => adBreak.active)
+          .filter((adBreak: YospaceAdBreak) => adBreak.duration > 0)
+      );
     },
 
     schedule: (adConfig: AdConfig) => {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -602,10 +602,12 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   private endAdImmunityPeriod() {
     if (typeof this.adImmunityCountDown === 'number') {
       window.clearTimeout(this.adImmunityCountDown);
+      this.adImmunityCountDown = null;
     }
 
+    if (!this.adImmune) return;
+
     this.adImmune = false;
-    this.adImmunityCountDown = null;
     Logger.log('[BitmovinYospacePlayer] Ad Immunity Ended');
     this.handleYospaceEvent<AdImmunityEndedEvent>({
       timestamp: Date.now(),

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -72,6 +72,7 @@ import {
   YospacePolicyErrorEvent,
   YospaceSourceConfig,
   AdImmunityStartedEvent,
+  AdImmunityConfig,
 } from './BitmovinYospacePlayerAPI';
 import { YospacePlayerError } from './YospaceError';
 import type {
@@ -574,7 +575,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.player.setPlaybackSpeed(this.playbackSpeed);
   }
 
-  setAdImmunityConfig(config: any) {
+  setAdImmunityConfig(config: AdImmunityConfig) {
     this.adImmunityConfig = config;
     Logger.log('[BitmovinYospacePlayer] Ad Immunity Configured:', this.adImmunityConfig);
     this.handleYospaceEvent<AdImmunityConfiguredEvent>({

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1232,7 +1232,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     // the offset is an attempt to prevent the first few frames of an ad
     // playing before the seek past the break has time to propagate
     const adBreakCheckOffset =
-      typeof this.adImmunityConfig.adBreakCheckOffset === 'number' ? this.adImmunityConfig.adBreakCheckOffset : 200;
+      typeof this.adImmunityConfig.adBreakCheckOffset === 'number' ? this.adImmunityConfig.adBreakCheckOffset : 300;
     const upcomingAdBreak: AdBreak | null = this.session.getAdBreakForPlayhead(
       toMilliseconds(event.time) + adBreakCheckOffset
     );

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -600,7 +600,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   // Helper
 
   private endAdImmunityPeriod() {
-    if (typeof this.adImmunityCountDown === 'number') {
+    if (this.adImmunityCountDown !== null) {
       window.clearTimeout(this.adImmunityCountDown);
       this.adImmunityCountDown = null;
     }

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -412,7 +412,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
         const breakStart = this.toMagicTime(toSeconds(adBreak.getStart()));
 
         // Check if break is being seeked past and deactivate it
-        if (breakStart > currentTime && breakStart < time) {
+        if (breakStart > currentTime && breakStart <= time) {
           Logger.log('[BitmovinYospacePlayer] Ad Immunity deactivated ad break during seek', adBreak);
           adBreak.setInactive();
         }

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -938,16 +938,12 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       this.session = null;
     }
 
-    if (this.adImmunityCountDown) {
-      window.clearTimeout(this.adImmunityCountDown);
-      this.adImmunityCountDown = null;
-    }
+    this.endAdImmunityPeriod();
 
     if (this.dateRangeEmitter) {
       this.dateRangeEmitter.reset();
     }
 
-    this.adImmune = false;
     // should adImmunityConfig be reset here? If yes, it
     // would require configuration for each new video start
     this.adParts = [];

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1229,12 +1229,6 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   };
 
   private performBreakSkip(seekTarget: number) {
-    this.suppressedEventsController.add(
-      this.player.exports.PlayerEvent.Paused,
-      this.player.exports.PlayerEvent.Seek,
-      this.player.exports.PlayerEvent.Seeked
-    );
-
     this.player.pause();
     this.unpauseAfterSeek = true;
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -52,6 +52,8 @@ import {
 import { DefaultBitmovinYospacePlayerPolicy } from './BitmovinYospacePlayerPolicy';
 import { ArrayUtils } from 'bitmovin-player-ui/dist/js/framework/arrayutils';
 import {
+  AdImmunityConfiguredEvent,
+  AdImmunityEndedEvent,
   BitmovinYospacePlayerAPI,
   BitmovinYospacePlayerPolicy,
   CompanionAdType,
@@ -69,6 +71,7 @@ import {
   YospacePolicyErrorCode,
   YospacePolicyErrorEvent,
   YospaceSourceConfig,
+  AdImmunityStartedEvent,
 } from './BitmovinYospacePlayerAPI';
 import { YospacePlayerError } from './YospaceError';
 import type {
@@ -573,10 +576,43 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
   setAdImmunityConfig(config: any) {
     this.adImmunityConfig = config;
+    Logger.log('[BitmovinYospacePlayer] Ad Immunity Configured:', this.adImmunityConfig);
+    this.handleYospaceEvent<AdImmunityConfiguredEvent>({
+      timestamp: Date.now(),
+      type: YospacePlayerEvent.AdImmunityConfigured,
+      config,
+    });
+  }
+
+  getAdImmunityConfig() {
+    return this.adImmunityConfig;
+  }
+
+  isAdImmunityActive() {
+    return this.adImmune;
+  }
+
+  endAdImmunity() {
+    this.endAdImmunityPeriod();
   }
 
   // Helper
-  private startAdHoliday() {
+
+  private endAdImmunityPeriod() {
+    if (typeof this.adImmunityCountDown === 'number') {
+      window.clearTimeout(this.adImmunityCountDown);
+    }
+
+    this.adImmune = false;
+    this.adImmunityCountDown = null;
+    Logger.log('[BitmovinYospacePlayer] Ad Immunity Ended');
+    this.handleYospaceEvent<AdImmunityEndedEvent>({
+      timestamp: Date.now(),
+      type: YospacePlayerEvent.AdImmunityEnded,
+    });
+  }
+
+  private startAdImmunityPeriod() {
     // only start a timer if a duration has been configured, and ad immunity is not
     // already active. Only enable for VOD content.
     if (this.adImmune || this.yospaceSourceConfig.assetType !== YospaceAssetType.VOD) {
@@ -585,9 +621,15 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       this.adImmune = true;
 
       this.adImmunityCountDown = window.setTimeout(() => {
-        this.adImmune = false;
-        this.adImmunityCountDown = null;
+        this.endAdImmunityPeriod();
       }, this.adImmunityConfig.duration);
+
+      Logger.log('[BitmovinYospacePlayer] Ad Immunity Started, duration', this.adImmunityConfig.duration);
+      this.handleYospaceEvent<AdImmunityStartedEvent>({
+        timestamp: Date.now(),
+        type: YospacePlayerEvent.AdImmunityStarted,
+        duration: this.adImmunityConfig.duration,
+      });
     }
   }
 
@@ -765,7 +807,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
     this.fireEvent<YospaceAdBreakEvent>(playerEvent);
 
-    this.startAdHoliday();
+    this.startAdImmunityPeriod();
 
     if (this.cachedSeekTarget) {
       this.seek(this.cachedSeekTarget, 'yospace-ad-skipping');
@@ -1190,6 +1232,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     if (upcomingAdBreak && !upcomingAdBreak.isActive()) {
       this.player.seek(toSeconds(upcomingAdBreak.getStart() + upcomingAdBreak.getDuration()));
 
+      Logger.log('[BitmovinYospacePlayer] - seeking past deactivated ad break');
       // do not propagate time to the rest of the app, we want to seek past it
       return;
     }
@@ -1198,6 +1241,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     if (upcomingAdBreak && this.adImmune) {
       upcomingAdBreak.setInactive();
 
+      Logger.log('[BitmovinYospacePlayer] - Ad Immunity - seeking past and deactivating ad break');
       this.player.seek(toSeconds(upcomingAdBreak.getStart() + upcomingAdBreak.getDuration()));
 
       // do not propagate time to the rest of the app, we want to seek past it

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -601,6 +601,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.endAdImmunityPeriod();
   }
 
+  startAdImmunity() {
+    this.startAdImmunityPeriod();
+  }
+
   // Helper
 
   private endAdImmunityPeriod() {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1129,8 +1129,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
           .getAdBreaksByType(BreakType.LINEAR)
           .map((adBreak: AdBreak) => this.mapAdBreak(adBreak))
           // filter out ad breaks deactivated by ad immunity
-          .filter((adBreak: YospaceAdBreak) => adBreak.active)
-          .filter((adBreak: YospaceAdBreak) => adBreak.duration > 0)
+          .filter((adBreak: YospaceAdBreak) => adBreak.active && adBreak.duration > 0)
       );
     },
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -151,7 +151,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
   private lastTimeChangedTime = 0;
   private adImmunityConfig = {
-    duration: 20000, // 0 duration = disabled
+    duration: 0, // 0 duration = disabled
   };
   private adImmune = false;
   private adImmunityCountDown: number | null = null;

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -154,6 +154,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   private adImmunityConfig: AdImmunityConfig = {
     duration: 0, // 0 duration = disabled
   };
+  // Ad holiday offset for discovering upcoming ad breaks before an ad frame is shown to the user
+  private defaultAdBreakCheckOffset = 0.3;
+
   private adImmune = false;
   private adImmunityCountDown: number | null = null;
   private unpauseAfterSeek = false;
@@ -1242,7 +1245,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     // the offset is an attempt to prevent the first few frames of an ad
     // playing before the seek past the break has time to propagate
     const adBreakCheckOffset =
-      typeof this.adImmunityConfig.adBreakCheckOffset === 'number' ? this.adImmunityConfig.adBreakCheckOffset : 0.3;
+      typeof this.adImmunityConfig.adBreakCheckOffset === 'number'
+        ? this.adImmunityConfig.adBreakCheckOffset
+        : this.defaultAdBreakCheckOffset;
     const upcomingAdBreak: AdBreak | null = this.session.getAdBreakForPlayhead(
       toMilliseconds(event.time) + toMilliseconds(adBreakCheckOffset)
     );

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -151,8 +151,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   private startSent: boolean;
 
   private lastTimeChangedTime = 0;
-  private adImmunityConfig = {
+  private adImmunityConfig: AdImmunityConfig = {
     duration: 0, // 0 duration = disabled
+    adBreakCheckOffset: 200,
   };
   private adImmune = false;
   private adImmunityCountDown: number | null = null;
@@ -1228,7 +1229,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     // the offset of 500ms is an attempt to prevent the
     // first few frames of an ad playing before the seek
     // past the break has time to propagate
-    const adBreakCheckOffset = 500;
+    const adBreakCheckOffset = this.adImmunityConfig.adBreakCheckOffset;
     const upcomingAdBreak: AdBreak | null = this.session.getAdBreakForPlayhead(
       toMilliseconds(event.time) + adBreakCheckOffset
     );


### PR DESCRIPTION
## Description
By providing an ad immunity configuration after initialization, a user that has watched an ad break will become immune to ad breaks for a period. Any ad break position passed during the immunity period is permanently disabled, so that it is not possible to enter the break at a later point after the immunity has expired. See changelog for more detailed description of new API methods.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
