### PR TITLE
Fix player bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Event loop on pre-roll ad end
+- Bitmovin Player getting bundled into the YospaceBitmovinPlayer
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
-
-- Event loop on pre-roll ad end
-- Bitmovin Player getting bundled into the YospaceBitmovinPlayer
-
 ### Added
 
 - `mode` argument to `getCurrentTime` to enable fetching absolute time including ad durations
 - `mode` argument to `getDuration` to enable fetching absolute duration including ad durations
+
+### Fixed
+
+- Event loop on pre-roll ad end
+- Bitmovin Player getting bundled into the YospaceBitmovinPlayer
 
 ## 2.3.1 - 2024-02-14
 

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AdaptationAPI,
   AudioQuality,
   AudioTrack,
@@ -35,9 +35,9 @@ import { InternalBitmovinYospacePlayer } from './InternalBitmovinYospacePlayer';
 import { Bitmovin8Adapter } from 'bitmovin-analytics';
 
 import { ArrayUtils } from 'bitmovin-player-ui/dist/js/framework/arrayutils';
-import { PlayerAdvertisingAPI } from 'bitmovin-player/modules/bitmovinplayer-advertising-core';
-import { PlayerVRAPI } from 'bitmovin-player/modules/bitmovinplayer-vr';
-import { PlayerSubtitlesAPI } from 'bitmovin-player/modules/bitmovinplayer-subtitles';
+import type { PlayerAdvertisingAPI } from 'bitmovin-player/modules/bitmovinplayer-advertising-core';
+import type { PlayerVRAPI } from 'bitmovin-player/modules/bitmovinplayer-vr';
+import type { PlayerSubtitlesAPI } from 'bitmovin-player/modules/bitmovinplayer-subtitles';
 import {
   BitmovinYospacePlayerAPI,
   BitmovinYospacePlayerExports,

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -1,14 +1,14 @@
-import {
-  AdBreak,
-  CompanionAd,
+import type {
   PlayerAPI,
   PlayerEvent,
   PlayerEventBase,
   PlayerEventCallback,
   PlayerExports,
   SourceConfig,
-} from 'bitmovin-player';
-import { TimeMode } from 'bitmovin-player/modules/bitmovinplayer-core';
+  TimeMode,
+} from 'bitmovin-player/modules/bitmovinplayer-core';
+
+import type { AdBreak, CompanionAd } from 'bitmovin-player/modules/bitmovinplayer-advertising-core';
 
 // Enums
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -408,7 +408,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   }
 
   getCurrentTime(mode?: TimeMode): number {
-    if (mode === TimeMode.AbsoluteTime) {
+    if (mode === 'absolutetime') {
       return this.player.getCurrentTime();
     }
 
@@ -424,7 +424,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   getDuration(mode?: TimeMode): number {
     if (!this.session) return 0;
 
-    if (mode === TimeMode.AbsoluteTime) {
+    if (mode === 'absolutetime') {
       return this.player.getDuration();
     }
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -19,7 +19,7 @@ import {
   YoLog,
 } from '@yospace/admanagement-sdk';
 
-import {
+import type {
   AdEvent,
   AdQuartile,
   AdQuartileEvent,
@@ -71,7 +71,7 @@ import {
   YospaceSourceConfig,
 } from './BitmovinYospacePlayerAPI';
 import { YospacePlayerError } from './YospaceError';
-import {
+import type {
   AdConfig,
   CompanionAd,
   LinearAd,


### PR DESCRIPTION
## Description
The Bitmovin Player was bundled into the output file by mistake. This was fixed and additional changes should make it more obvious that **only types** of the Bitmovin Player might be used by changing imports to `import type`.

This wrong bundling led to unnecessary file size increase, but could also create more problems if the bundled player version doesn't match the player version used by the application

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
