### PR TITLE
Feature/fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Parsing non-Yospace ID3 tags and passing those to the Yospace SDK
+- Small memory leak where player listeners were not detached
 
 ## [2.5.0] - 2024-07-10
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1193,8 +1193,8 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.player.off(this.player.exports.PlayerEvent.StallStarted, this.onStallStarted);
     this.player.off(this.player.exports.PlayerEvent.StallEnded, this.onStallEnded);
 
-    this.player.on(this.player.exports.PlayerEvent.Muted, this.onMuted);
-    this.player.on(this.player.exports.PlayerEvent.Unmuted, this.onUnmuted);
+    this.player.off(this.player.exports.PlayerEvent.Muted, this.onMuted);
+    this.player.off(this.player.exports.PlayerEvent.Unmuted, this.onUnmuted);
 
     // To support ads in live streams we need to track metadata events
     this.player.off(this.player.exports.PlayerEvent.Metadata, this.onMetaData);


### PR DESCRIPTION
## Description
Some event listeners were not detached, leading to a potential small memory leak. Now they are detached (`player.off`).

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
