### PR TITLE
Enhance AdImmunity with only temporarily disabled ad breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `AdImmunityConfig.disablePassedAdBreaks` option to only temporarily disable ad breaks during the ad immunity instead of disabling them for the whole session
+
 ## [2.6.0] - 2024-09-25
 
 ### Changed

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -153,7 +153,6 @@ export interface YospaceConfiguration {
   debug?: boolean;
   debugYospaceSdk?: boolean;
   disableServiceWorker?: boolean;
-  disableStrictBreaks?: boolean;
   useTizen?: boolean;
   useWebos?: boolean;
 }

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -276,4 +276,11 @@ export interface AdImmunityEndedEvent extends YospaceEventBase {
 export interface AdImmunityConfig {
   duration: number;
   adBreakCheckOffset?: number;
+
+  /**
+   * Flag to set if ad breaks the user passes during active ad immunity, by playing or seeking, should be disabled
+   * or not. Disabled ad breaks won't be shown to the user again in this session.
+   * Default is true (ad breaks will be disabled).
+   */
+  disablePassedAdBreaks?: boolean;
 }

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -71,17 +71,15 @@ export interface BitmovinYospacePlayerAPI extends PlayerAPI {
   forceSeek(time: number, issuer?: string): boolean;
 
   /**
-   * Provide a duration in seconds greater than 0 to enable the ad immunity feature.
-   * The user will become immune to ad breaks for the duration upon
-   * fully watching an ad break.
+   * Provide a duration in seconds greater than 0 to enable the ad immunity feature. The user will become immune to ad
+   * breaks for the duration upon fully watching an ad break.
    *
-   * Ad breaks played over or seeked past during immunity will be marked
-   * as deactivated, making the user permanently immune to those breaks.
+   * Ad breaks played over or seeked past during immunity will be marked as deactivated, making the user permanently
+   * immune to those breaks (unless `AdImmunityConfig.disablePassedAdBreaks` is set to `false`).
    *
-   * Post-rolls are excluded from ad immunity
+   * Post-rolls are excluded from ad immunity.
    *
-   * Pre-roll ads are excluded from ad immunity as at least one ad break needs to be
-   * watched completely
+   * Pre-roll ads are excluded from ad immunity as at least one ad break needs to be watched completely.
    */
   setAdImmunityConfig(options: AdImmunityConfig): void;
 
@@ -266,14 +264,16 @@ export interface AdImmunityEndedEvent extends YospaceEventBase {
   type: YospacePlayerEvent.AdImmunityEnded;
 }
 
-/**
- * @description Ad Immunity Configuration Object
- * @property duration - a number indicating the duration of the ad immunity period. 0 disables the feature.
- * @property adBreakCheckOffset - a number indicating how far ahead ad immunity should look for ad breaks
- * to skip past, in order to mitigate ad frames being displayed before they have time to be seeked past.
- */
 export interface AdImmunityConfig {
+  /**
+   * A number indicating the duration in seconds of the ad immunity period. 0 disables the feature.
+   */
   duration: number;
+
+  /**
+   * A number indicating how far ahead ad immunity should look for ad breaks to skip past, in order to mitigate ad
+   * frames being displayed before they have time to be seeked past.
+   */
   adBreakCheckOffset?: number;
 
   /**

--- a/web/index.html
+++ b/web/index.html
@@ -216,7 +216,6 @@
       var yospaceConfig = {
         debug: debugOverride && !isValidationMode,
         debugYospaceSdk: isValidationMode,
-        disableStrictBreaks: false,
         disableServiceWorker: false,
         useTizen: platformType === 'tizen',
         useWebos: platformType === 'webos',


### PR DESCRIPTION
## Description
This PR adds a new config option `disablePassedAdBreaks` to the existing `AdImmunityConfig`. This allows users of the integration to specify if ad breaks that are skipped or seeked over during the ad immunity should be permanently disabled (config set to `true`) so that the user never sees those ad breaks again, or if this should be only temporarily (config set to `false`) while the ad immunity phase is active.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
