### PR TITLE
Fix load error promise rejection reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Yospace error on source load and session initialization not returned in `load` promise rejection as reason
+
 ## [2.7.0] - 2024-09-27
 
 ### Added

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -17,6 +17,7 @@ import {
   TimedMetadata,
   UNKNOWN_FORMAT,
   YoLog,
+  DebugFlags,
 } from '@yospace/admanagement-sdk';
 
 import type {
@@ -296,7 +297,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       properties.setUserAgent(navigator.userAgent);
 
       if (this.yospaceConfig.debug || this.yospaceConfig.debugYospaceSdk) {
-        YoLog.setDebugFlags(DEBUG_ALL);
+        YoLog.setDebugFlags(DebugFlags.DEBUG_ALL);
       }
 
       switch (source.assetType) {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -195,8 +195,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return new Promise<void>((resolve, reject) => {
       if (!source.hls && !source.dash) {
         this.resetState();
-        this.handleYospaceError(new YospacePlayerError(YospaceErrorCode.SUPPORTED_SOURCE_MISSING));
-        reject();
+        const yospaceError = new YospacePlayerError(YospaceErrorCode.SUPPORTED_SOURCE_MISSING);
+        this.handleYospaceError(yospaceError);
+        reject(yospaceError);
         return;
       }
       this.resetState();
@@ -285,8 +286,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
           session.shutdown();
           this.session = null;
 
-          this.handleYospaceError(getYospaceError());
-          reject();
+          const yospaceError = getYospaceError();
+          this.handleYospaceError(yospaceError);
+          reject(yospaceError);
         }
       };
 


### PR DESCRIPTION
## Description
If an error happens during source load and Yospace session initialization, the Yospace error was not returned as the `Promise.reject` reason

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
