### PR TITLE
Fix seeking in Ad Immunity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Yospace error on source load and session initialization not returned in `load` promise rejection as reason
+- Seeking over ad breaks during ad immunity led to wrong seek end position
+- Default policy not aware of ad immunity, sometimes leading to wrong decisions for `canSeekTo`
 
 ## [2.7.0] - 2024-09-27
 

--- a/src/ts/BitmovinYospacePlayerPolicy.ts
+++ b/src/ts/BitmovinYospacePlayerPolicy.ts
@@ -22,7 +22,7 @@ export class DefaultBitmovinYospacePlayerPolicy implements BitmovinYospacePlayer
       return adBreak.active && adBreak.scheduleTime > currentTime && adBreak.scheduleTime < seekTarget;
     });
 
-    if (skippedAdBreaks.length > 0) {
+    if (skippedAdBreaks.length > 0 && !this.player.isAdImmunityActive()) {
       const adBreakToPlay = skippedAdBreaks[skippedAdBreaks.length - 1];
       return adBreakToPlay.scheduleTime;
     }

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -813,7 +813,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
     this.startAdImmunityPeriod();
 
-    if (this.cachedSeekTarget) {
+    if (this.cachedSeekTarget !== null) {
       this.seek(this.cachedSeekTarget, 'yospace-ad-skipping');
       this.cachedSeekTarget = null;
     }
@@ -1223,7 +1223,12 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.player.pause();
     this.unpauseAfterSeek = true;
 
-    this.player.seek(seekTarget);
+    if (this.cachedSeekTarget !== null) {
+      this.player.seek(this.cachedSeekTarget, 'yospace-ad-skipping');
+      this.cachedSeekTarget = null;
+    } else {
+      this.seek(seekTarget);
+    }
   }
 
   private onTimeChanged = (event: TimeChangedEvent) => {

--- a/web/index.html
+++ b/web/index.html
@@ -281,13 +281,13 @@
           });
         });
 
-        ['moduleready', 'playing', 'metadata', 'metadataparsed'].forEach(function (eventName) {
+        ['moduleready', 'playing', 'metadata', 'metadataparsed', 'adimmunitystarted', 'adimmunityended'].forEach(function (eventName) {
           yospacePlayer.on(eventName, function (event) {
             log(createLogFromEvent(event));
           });
         });
 
-        ['error', 'yospaceerror', 'aderror'].forEach(function (eventName) {
+        ['error', 'yospaceerror', 'policyerror', 'aderror'].forEach(function (eventName) {
           yospacePlayer.on(eventName, function (event) {
             console.error(createLogFromEvent(event));
           });

--- a/web/index.html
+++ b/web/index.html
@@ -293,7 +293,8 @@
           });
         });
 
-        yospacePlayer.setPolicy(simplePolicy);
+        // We are using the default, built-in policy in the demo. Another policy can easily be set using this method:
+        // yospacePlayer.setPolicy(simplePolicy);
 
         yospacePlayer.on('segmentplayback', function (event) {
           if (event.mimeType === 'video/mp4') {


### PR DESCRIPTION
## Description
Seeking over multiple ad breaks with the default policy led to wrong seek end positions. The default policy is now also aware of ad immunity, and the internal ad break skipping uses the cached seek time, if one is available.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
