### PR TITLE
Add support for `DVRLIVE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for the `DVRLIVE` PlaybackMode to not rely on Metadata parsing for live streams anymore
+
 ## [2.7.1] - 2024-10-03
 
 ### Fixed

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -13,6 +13,9 @@ import type { AdBreak, CompanionAd } from 'bitmovin-player/modules/bitmovinplaye
 // Enums
 
 export enum YospaceAssetType {
+  /**
+   * @deprecated Use `DVRLIVE` instead for a wider compatibility
+   */
   LINEAR,
   VOD,
   DVRLIVE,

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -15,6 +15,7 @@ import type { AdBreak, CompanionAd } from 'bitmovin-player/modules/bitmovinplaye
 export enum YospaceAssetType {
   LINEAR,
   VOD,
+  DVRLIVE,
 }
 
 export enum YospacePlayerType {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -202,11 +202,12 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
         return;
       }
       this.resetState();
-      this.registerPlayerEvents();
 
       const url = source.hls || source.dash;
-
       this.yospaceSourceConfig = source;
+
+      this.registerPlayerEvents();
+
       const onInitComplete = (event: any) => {
         const session: Session = event.getPayload();
         const state = session.getSessionState();
@@ -1185,8 +1186,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.player.on(this.player.exports.PlayerEvent.Muted, this.onMuted);
     this.player.on(this.player.exports.PlayerEvent.Unmuted, this.onUnmuted);
 
-    // To support ads in live streams we need to track metadata events
-    this.player.on(this.player.exports.PlayerEvent.Metadata, this.onMetaData);
+    if (this.yospaceSourceConfig.assetType === YospaceAssetType.LINEAR) {
+      // To support ads in live streams we need to track metadata events
+      this.player.on(this.player.exports.PlayerEvent.Metadata, this.onMetaData);
+    }
   }
 
   private unregisterPlayerEvents(): void {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1280,7 +1280,15 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     this.lastTimeChangedTime = event.time;
 
     if (timeDifference >= 0 || timeDifference < -0.25) {
-      this.session.onPlayheadUpdate(toMilliseconds(event.time));
+      let playheadTime: number;
+
+      if (this.yospaceSourceConfig.assetType === YospaceAssetType.DVRLIVE) {
+        playheadTime = this.player.getCurrentTime('relativetime' as any);
+      } else {
+        playheadTime = event.time;
+      }
+
+      this.session.onPlayheadUpdate(toMilliseconds(playheadTime));
     } else {
       Logger.warn('Encountered a small negative TimeChanged update, not reporting to Yospace. Difference was: ' + timeDifference);
     }

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -5,11 +5,12 @@ import {
   BreakType,
   CONNECTION_ERROR,
   CONNECTION_TIMEOUT,
-  DEBUG_ALL,
+  DebugFlags,
   MALFORMED_URL,
   PlayerEvent as YsPlayerEvent,
   ResourceType,
   Session,
+  SessionDVRLive,
   SessionLive,
   SessionProperties,
   SessionState,
@@ -17,7 +18,6 @@ import {
   TimedMetadata,
   UNKNOWN_FORMAT,
   YoLog,
-  DebugFlags,
 } from '@yospace/admanagement-sdk';
 
 import type {
@@ -53,8 +53,10 @@ import {
 import { DefaultBitmovinYospacePlayerPolicy } from './BitmovinYospacePlayerPolicy';
 import { ArrayUtils } from 'bitmovin-player-ui/dist/js/framework/arrayutils';
 import {
+  AdImmunityConfig,
   AdImmunityConfiguredEvent,
   AdImmunityEndedEvent,
+  AdImmunityStartedEvent,
   BitmovinYospacePlayerAPI,
   BitmovinYospacePlayerPolicy,
   CompanionAdType,
@@ -72,8 +74,6 @@ import {
   YospacePolicyErrorCode,
   YospacePolicyErrorEvent,
   YospaceSourceConfig,
-  AdImmunityStartedEvent,
-  AdImmunityConfig,
 } from './BitmovinYospacePlayerAPI';
 import { YospacePlayerError } from './YospaceError';
 import type {
@@ -307,6 +307,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
           break;
         case YospaceAssetType.VOD:
           SessionVOD.create(url, properties, onInitComplete);
+          break;
+        case YospaceAssetType.DVRLIVE:
+          SessionDVRLive.create(url, properties, onInitComplete);
           break;
         default:
           Logger.error('Undefined YospaceSourceConfig.assetType; Could not obtain session;');

--- a/web/js/sources.js
+++ b/web/js/sources.js
@@ -23,11 +23,15 @@ var sources = {
   linear: {
     yospaceValidation: {
       title: 'Yospace Validation',
-      dash: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk01,t2-dash.mpd?yo.av=3', // v0 emsg
-      // dash: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk01,dash.mpd?yo.av=3', // v1 emsg
-      // hls: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yospace02,hlssample42.m3u8?yo.br=true&yo.av=3',
+      hls: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts.m3u8?yo.br=true&yo.av=4',
       // Yospace configuration
       assetType: bitmovin.player.ads.yospace.YospaceAssetType.LINEAR,
+    },
+    dvrLive: {
+      title: 'DVR Live',
+      hls: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true',
+      // Yospace configuration
+      assetType: bitmovin.player.ads.yospace.YospaceAssetType.DVRLIVE,
     },
   },
 };

--- a/web/js/sources.js
+++ b/web/js/sources.js
@@ -23,12 +23,14 @@ var sources = {
   linear: {
     yospaceValidation: {
       title: 'Yospace Validation',
+      // dash: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,dash-mp4.mpd?yo.br=true&yo.av=4',
       hls: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts.m3u8?yo.br=true&yo.av=4',
       // Yospace configuration
       assetType: bitmovin.player.ads.yospace.YospaceAssetType.LINEAR,
     },
     dvrLive: {
       title: 'DVR Live',
+      // dash: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,dash-mp4-pre.mpd?yo.br=false&yo.av=4&yo.lp=true',
       hls: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true',
       // Yospace configuration
       assetType: bitmovin.player.ads.yospace.YospaceAssetType.DVRLIVE,


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
### Problem
We do not support the `DVRLIVE` feature from YoSpace yet. The DVRLIVE feature allows us to not relly on metadata events but use the current time instead also for live streams.

### Changes
Added a new DVRLIVE option to the `YospaceAssetType` and handle it accordingly in the YoSpace integration. See comments below for details.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
