### PR TITLE
Fix AdBreak skipping with ad immunity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for the `DVRLIVE` PlaybackMode to not rely on Metadata parsing for live streams anymore
 
+### Fixed
+
+- Wrong playback position after skipping over ad breaks using ad immunity
+
 ## [2.7.1] - 2024-10-03
 
 ### Fixed

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -300,7 +300,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       const properties = new SessionProperties();
       properties.setUserAgent(navigator.userAgent);
 
-      if (this.yospaceConfig.debug || this.yospaceConfig.debugYospaceSdk) {
+      if (this.yospaceConfig.debugYospaceSdk) {
         YoLog.setDebugFlags(DebugFlags.DEBUG_ALL);
       }
 
@@ -1237,7 +1237,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       this.player.seek(this.cachedSeekTarget, 'yospace-ad-skipping');
       this.cachedSeekTarget = null;
     } else {
-      this.seek(seekTarget);
+      this.player.seek(seekTarget, 'yospace-ad-skipping');
     }
   }
 


### PR DESCRIPTION
## Description
Skipping over Ad Breaks during ad immunity resulted in wrong playback position. This was due to - in some cases - using the public `player.seek` method, which then takes ads into account. However, the calculated seek position has all that taken into account already.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
