### PR TITLE
Improve live stream startup behavior with preroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve startup behavior for `LINEAR` and `DVRLIVE` streams according to https://developer.yospace.com/sdk-documentation/javascript/userguide/yosdk/latest/en/optimising-user-experience-at-video-start.html
+
 ### Fixed
 
 - Missing `issuer` in `Muted`, `Unmuted` and `Paused` events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Missing `issuer` in `Muted`, `Unmuted` and `Paused` events
+
 ## [2.8.0] - 2024-10-30
 
 ### Added

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -559,7 +559,7 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   }
 
   unmute(issuer?: string): void {
-    return this.player.unmute();
+    return this.player.unmute(issuer);
   }
 
   setAspectRatio(aspectratio: string | number): void {

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -483,11 +483,11 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   }
 
   mute(issuer?: string): void {
-    return this.player.mute();
+    return this.player.mute(issuer);
   }
 
   pause(issuer?: string): void {
-    return this.player.pause();
+    return this.player.pause(issuer);
   }
 
   play(issuer?: string): Promise<void> {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -288,8 +288,8 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
           Logger.log('Loading Source: ' + stringify(clonedSource));
           this.player
             .load(clonedSource, forceTechnology, disableSeeking)
-            .then(() => this.pullYospaceAdDataForLive())
-            .then(() => resolve())
+            .then(this.pullYospaceAdDataForLive)
+            .then(resolve)
             .catch(reject);
         } else {
           session.shutdown();

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -286,11 +286,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
           }
 
           Logger.log('Loading Source: ' + stringify(clonedSource));
-          this.player
-            .load(clonedSource, forceTechnology, disableSeeking)
-            .then(this.pullYospaceAdDataForLive)
-            .then(resolve)
-            .catch(reject);
+          this.player.load(clonedSource, forceTechnology, disableSeeking).then(this.pullYospaceAdDataForLive).then(resolve).catch(reject);
         } else {
           session.shutdown();
           this.session = null;
@@ -390,7 +386,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.play(issuer);
   }
 
-  private pullYospaceAdDataForLive(): Promise<void> {
+  private pullYospaceAdDataForLive = (): Promise<void> => {
     if (
       (this.yospaceSourceConfig.assetType !== YospaceAssetType.DVRLIVE && this.yospaceSourceConfig.assetType !== YospaceAssetType.LINEAR) ||
       this.startSent
@@ -410,8 +406,8 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 
     this.session.onPlayerEvent(YsPlayerEvent.PLAYBACK_READY, 0);
 
-    return adBreakUpdatePromise;
-  }
+    return adDataUpdatedPromise;
+  };
 
   pause(issuer?: string): void {
     this.playerPolicy.canPause() ? this.player.pause(issuer) : this.handleYospacePolicyEvent(YospacePolicyErrorCode.PAUSE_NOT_ALLOWED);

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -399,7 +399,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       return Promise.resolve();
     }
 
-    const adBreakUpdatePromise = new Promise<void>((resolve, reject) => {
+    const adDataUpdatedPromise = new Promise<void>((resolve, reject) => {
       const onAnalyticUpdate = () => {
         this.yospaceListenerAdapter.removeListener(BYSListenerEvent.ANALYTIC_UPDATED, onAnalyticUpdate);
         resolve();

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -387,19 +387,11 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   }
 
   pause(issuer?: string): void {
-    if (this.playerPolicy.canPause()) {
-      this.player.pause();
-    } else {
-      this.handleYospacePolicyEvent(YospacePolicyErrorCode.PAUSE_NOT_ALLOWED);
-    }
+    this.playerPolicy.canPause() ? this.player.pause(issuer) : this.handleYospacePolicyEvent(YospacePolicyErrorCode.PAUSE_NOT_ALLOWED);
   }
 
   mute(issuer?: string): void {
-    if (this.playerPolicy.canMute()) {
-      this.player.mute();
-    } else {
-      this.handleYospacePolicyEvent(YospacePolicyErrorCode.MUTE_NOT_ALLOWED);
-    }
+    this.playerPolicy.canMute() ? this.player.mute(issuer) : this.handleYospacePolicyEvent(YospacePolicyErrorCode.MUTE_NOT_ALLOWED);
   }
 
   /**

--- a/src/ts/YospaceListenerAdapter.ts
+++ b/src/ts/YospaceListenerAdapter.ts
@@ -116,11 +116,11 @@ export class YospaceAdListenerAdapter {
     Logger.warn('[BYP][listener] onAdvertBreakEarlyReturn not implemented');
   }
 
-  onSessionError() {
+  onSessionError(errorCode: SessionErrorCode) {
     Logger.warn('[BYP][listener] onSessionError not implemented');
   }
 
-  onTrackingError() {
+  onTrackingError(trackingError: TrackingError) {
     Logger.warn('[BYP][listener] onTrackingError not implemented');
   }
 

--- a/src/ts/YospaceListenerAdapter.ts
+++ b/src/ts/YospaceListenerAdapter.ts
@@ -10,6 +10,7 @@ export enum BYSListenerEvent {
   ADVERT_END = 'advert_end',
   AD_BREAK_END = 'ad_break_end',
   ANALYTICS_FIRED = 'analytics_fired',
+  ANALYTIC_UPDATED = 'analytics_updated',
 }
 
 export type BYSTrackingEventType =
@@ -95,7 +96,9 @@ export class YospaceAdListenerAdapter {
   }
 
   onAnalyticUpdate() {
-    // No op
+    this.emitEvent({
+      type: BYSListenerEvent.ANALYTIC_UPDATED,
+    } as BYSListenerEventBase);
   }
 
   onTrackingEvent(type: BYSTrackingEventType) {

--- a/src/ts/YospaceListenerAdapter.ts
+++ b/src/ts/YospaceListenerAdapter.ts
@@ -1,6 +1,7 @@
-import { AdBreak, Advert } from '@yospace/admanagement-sdk';
 import { ArrayUtils } from 'bitmovin-player-ui/dist/js/framework/arrayutils';
 import { Logger } from './Logger';
+import type { AdBreak, Advert, Session, SessionErrorCode } from '@yospace/admanagement-sdk';
+import type { TrackingError } from '@yospace/admanagement-sdk/types/Public/TrackingError';
 
 /** BYS -> BitmovinYospace */
 export enum BYSListenerEvent {


### PR DESCRIPTION
## Description
Previously, if a live (`LINEAR` or `DVRLIVE`) stream was started with a pre-roll ad, playback started but the ad break information would come late. This led to situations where the non-ads UI was visible for some time before switching to the ads UI during ads playback.

The integration is now following the guidelines from https://developer.yospace.com/sdk-documentation/javascript/userguide/yosdk/latest/en/optimising-user-experience-at-video-start.html to improve this behavior. The `SourceLoaded` will only be triggered and the `load` Promise will only resolve once the Yospace SDK received and propagated the ad information update.

Also fixed the missing pass-through of the `issuer` parameter for some methods to the events, namely `mute` (`Muted` event), `unmute` (`Unmuted` event) and `pause` (`Paused` event).

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
