### PR TITLE
Improve destroy handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Calling `destroy` during an ongoing `load` process resulted in non-capturable error being thrown
+
 ## [2.9.0] - 2024-12-05
 
 ### Changed

--- a/src/ts/BitmovinYospacePlayer.ts
+++ b/src/ts/BitmovinYospacePlayer.ts
@@ -231,6 +231,11 @@ export class BitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   }
 
   destroy(): Promise<void> {
+    this.BitmovinPlayerStaticApi = null;
+    this.containerElement = null;
+    this.config = null;
+    this.yospaceConfig = null;
+
     return this.player.destroy();
   }
 

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -286,7 +286,11 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
           }
 
           Logger.log('Loading Source: ' + stringify(clonedSource));
-          this.player.load(clonedSource, forceTechnology, disableSeeking).then(this.pullYospaceAdDataForLive).then(resolve).catch(reject);
+          try {
+            this.player.load(clonedSource, forceTechnology, disableSeeking).then(this.pullYospaceAdDataForLive).then(resolve).catch(reject);
+          } catch (e) {
+            reject(e);
+          }
         } else {
           session.shutdown();
           this.session = null;

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -1441,6 +1441,14 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return this.player.unload();
   }
 
+  destroy(): Promise<void> {
+    if (this.isAdActive()) {
+      this.ads.skip();
+    }
+    this.resetState();
+    return this.player.destroy();
+  }
+
   // Needed in BitmovinYospacePlayerPolicy.ts so keep it here
   isLive(): boolean {
     return this.player.isLive();

--- a/web/index.html
+++ b/web/index.html
@@ -212,10 +212,10 @@
 
       /* end of queryParameters */
 
-
       var bitmovinPlayerLicenseKey = 'YOUR-KEY';
 
       var yospacePlayer;
+      var uiManager;
     </script>
     <script type="text/javascript" src="js/pageSetup.js"></script>
     <script type="text/javascript">
@@ -293,7 +293,7 @@
           yospaceConfig
         );
 
-        var uiManager = new bitmovin.playerui.UIFactory.buildDefaultUI(yospacePlayer);
+        uiManager = new bitmovin.playerui.UIFactory.buildDefaultUI(yospacePlayer);
 
         yospacePlayer.on('sourceloaded', function (event) {
           log(createLogFromEvent(event));


### PR DESCRIPTION
## Description
When the player is destroyed, not all BitmovinYospacePlayer internals were properly cleaned up, but should be now.

Additionally, calling `destroy` during an ongoing `load` process led to an error being thrown which the application cannot catch. This error was thrown from the Bitmovin Player, and now this is caught by the integration code and surfaced as `load.reject` as expected.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
