### PR TITLE
Fix player.ads.getActiveAdBreak() wrongly returning undefined between two ads in an ad break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Calling AdvertisingApi.getActiveAdBreak() when player is briefly in-between adFinished and adStarted events resulted in undefined being returned
+
 ## [2.9.1] - 2025-02-10
 
 ### Fixed

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -674,6 +674,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     return Boolean(this.getCurrentAd());
   }
 
+  private isAdBreakActive(): boolean {
+    return Boolean(this.getCurrentAdBreak());
+  }
+
   private getCurrentAdDuration(): number {
     if (this.isAdActive()) {
       return this.getAdDuration(this.getCurrentAd());
@@ -1111,7 +1115,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     },
 
     getActiveAdBreak: () => {
-      if (!this.isAdActive()) {
+      if (!this.isAdBreakActive()) {
         return undefined;
       }
 


### PR DESCRIPTION
## Description
`player.ads.getActiveAdBreak` wrongly checked if an ad is currently active as early return condition, which led to no `AdBreak` object being returned for the short time between an `AdFinished` and the next `AdStarted` event.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
