### PR TITLE
fix: prevent invalid calls to session position methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent errors relating to method calls on undefined when starting non-VOD content
+
 ## [2.9.2] - 2025-03-24
 
 ### Fixed

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -493,7 +493,11 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
       return this.player.getDuration();
     }
 
-    return toSeconds((this.session as SessionVOD).getContentPositionForPlayhead(toMilliseconds(this.player.getDuration())));
+    if (!(this.session instanceof SessionVOD)) {
+      return this.player.getDuration();
+    }
+
+    return toSeconds(this.session.getContentPositionForPlayhead(toMilliseconds(this.player.getDuration())));
   }
 
   /**
@@ -911,6 +915,10 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     if (this.isLive()) return playbackTime;
     if (!this.session) return playbackTime;
 
+    if (!(this.session instanceof SessionVOD)) {
+      return playbackTime;
+    }
+
     /**
      * Provides a relative content playhead position to the client,
      * discounting the sum of all ad break durations prior to the
@@ -918,12 +926,16 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
      * to return to the same content position if a VOD stream is
      * stopped before playback ends.
      */
-    return toSeconds((this.session as SessionVOD).getContentPositionForPlayhead(toMilliseconds(playbackTime)));
+    return toSeconds(this.session.getContentPositionForPlayhead(toMilliseconds(playbackTime)));
   }
 
   private toAbsoluteTime(relativeTime: number): number {
     if (this.yospaceSourceConfig.assetType === YospaceAssetType.VOD) {
       if (!this.session) return relativeTime;
+
+      if (!(this.session instanceof SessionVOD)) {
+        return relativeTime;
+      }
 
       /**
        * Provides an absolute playhead position to the client
@@ -933,7 +945,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
        * the same content position if a VOD stream is stopped
        * before playback ends.
        */
-      return toSeconds((this.session as SessionVOD).getPlayheadForContentPosition(toMilliseconds(relativeTime)));
+      return toSeconds(this.session.getPlayheadForContentPosition(toMilliseconds(relativeTime)));
     } else {
       return relativeTime;
     }


### PR DESCRIPTION
## Description

I've noticed in the demo app that the integration manages to call these methods when it shouldn't, triggering "X is not a method on session" errors. I've not investigated why this happens, but I've added the code required to ensure that it shouldn't happen any more. 
