### PR TITLE
feat!: allow null ad breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+BREAKING CHANGES:
+The adBreak property on the payload of the YospaceAdBreakEvent can now be null.
+
+### Fixed
+
+- Prevent Yospace integration crashing internally when the AdBreak for an even raised by the Yospace SDK is null
+
+### Changed
+
+- AdBreaks can now be null, which aligns with the Yospace SDK API. It is possible that the Yospace SDK has not had time to parse the metadata by the time the ad break triggers, which can cause the ad break to be null by the time the break starts.
+
 ## [2.9.2] - 2025-03-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-BREAKING CHANGES:
-The adBreak property on the payload of the YospaceAdBreakEvent can now be null.
-
 ### Fixed
 
-- Prevent Yospace integration crashing internally when the AdBreak for an even raised by the Yospace SDK is null
+- Prevent Yospace integration crashing internally when the AdBreak for an event raised by the Yospace SDK is null
 
 ### Changed
 
-- AdBreaks can now be null, which aligns with the Yospace SDK API. It is possible that the Yospace SDK has not had time to parse the metadata by the time the ad break triggers, which can cause the ad break to be null by the time the break starts.
+- AdBreaks can now be null, which aligns with reality. It is possible for the Yospace SDK to not have had time to parse the metadata by the time the ad break triggers, which can cause the ad break to be null by the time the break starts. Note: the yospace documentation is wrongly indicating that this shouldn't be the case
 
 ## [2.9.2] - 2025-03-24
 

--- a/src/ts/BitmovinYospacePlayerAPI.ts
+++ b/src/ts/BitmovinYospacePlayerAPI.ts
@@ -126,7 +126,7 @@ export interface YospaceAdBreak extends AdBreak {
 }
 
 export interface YospaceAdBreakEvent extends PlayerEventBase {
-  adBreak: YospaceAdBreak;
+  adBreak: YospaceAdBreak | null;
 }
 
 export interface YospaceCompanionAd extends CompanionAd {

--- a/src/ts/InternalBitmovinYospacePlayer.ts
+++ b/src/ts/InternalBitmovinYospacePlayer.ts
@@ -735,8 +735,11 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
     Logger.log('[BitmovinYospacePlayer] yospaceListenerAdapter.AD_BREAK_START');
     this.player.setPlaybackSpeed(1);
 
-    const adBreak = this.mapAdBreak(event.adBreak);
-    const playerEvent = AdEventsFactory.createAdBreakEvent(this.player.exports.PlayerEvent.AdBreakStarted, adBreak);
+    const playerEvent = AdEventsFactory.createAdBreakEvent(
+      this.player.exports.PlayerEvent.AdBreakStarted,
+      event.adBreak ? this.mapAdBreak(event.adBreak) : null
+    );
+
     this.fireEvent<YospaceAdBreakEvent>(playerEvent);
   };
 
@@ -835,9 +838,12 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
   };
 
   private onAdBreakFinished = () => {
-    const adBreak = this.mapAdBreak(this.getCurrentAdBreak());
+    const adBreak = this.getCurrentAdBreak();
 
-    const playerEvent = AdEventsFactory.createAdBreakEvent(this.player.exports.PlayerEvent.AdBreakFinished, adBreak);
+    const playerEvent = AdEventsFactory.createAdBreakEvent(
+      this.player.exports.PlayerEvent.AdBreakFinished,
+      adBreak ? this.mapAdBreak(adBreak) : null
+    );
 
     this.fireEvent<YospaceAdBreakEvent>(playerEvent);
 
@@ -1119,7 +1125,9 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
         return undefined;
       }
 
-      return this.mapAdBreak(this.getCurrentAdBreak());
+      const adBreak = this.getCurrentAdBreak();
+
+      return adBreak ? this.mapAdBreak(adBreak) : null;
     },
 
     getActiveAd: () => {
@@ -1522,7 +1530,7 @@ export class InternalBitmovinYospacePlayer implements BitmovinYospacePlayerAPI {
 }
 
 class AdTranslator {
-  static mapYsAdvert(ysAd: Advert): LinearAd {
+  static mapYsAdvert(ysAd: Advert): LinearAd | null {
     if (!ysAd || ysAd.isNonLinear()) {
       return null;
     }
@@ -1585,7 +1593,7 @@ class AdTranslator {
 }
 
 class AdEventsFactory {
-  static createAdBreakEvent(type: PlayerEvent, adBreak: YospaceAdBreak): YospaceAdBreakEvent {
+  static createAdBreakEvent(type: PlayerEvent, adBreak: YospaceAdBreak | null): YospaceAdBreakEvent {
     return {
       timestamp: Date.now(),
       type: type,

--- a/src/ts/YospaceListenerAdapter.ts
+++ b/src/ts/YospaceListenerAdapter.ts
@@ -1,7 +1,8 @@
 import { ArrayUtils } from 'bitmovin-player-ui/dist/js/framework/arrayutils';
 import { Logger } from './Logger';
-import type { AdBreak, Advert, Session, SessionErrorCode } from '@yospace/admanagement-sdk';
+import type { AdBreak, Advert, SessionErrorCode } from '@yospace/admanagement-sdk';
 import type { TrackingError } from '@yospace/admanagement-sdk/types/Public/TrackingError';
+import { AnalyticEventObserver } from '@yospace/admanagement-sdk';
 
 /** BYS -> BitmovinYospace */
 export enum BYSListenerEvent {
@@ -38,7 +39,7 @@ export interface BYSAdEvent extends BYSListenerEventBase {
 }
 
 export interface BYSAdBreakEvent extends BYSListenerEventBase {
-  adBreak: AdBreak;
+  adBreak: AdBreak | null;
 }
 
 export interface BYSAnalyticsFiredEvent extends BYSListenerEventBase {
@@ -54,7 +55,7 @@ interface BYSListenerCallbackFunction {
  * The default way would be to pass an object to Yospace with the structure of this class.
  * To simplify the Yospace callbacks handling this Adapter was introduced.
  */
-export class YospaceAdListenerAdapter {
+export class YospaceAdListenerAdapter extends AnalyticEventObserver {
   private listeners: { [eventType: string]: BYSListenerCallbackFunction[] } = {};
 
   addListener(event: BYSListenerEvent, callback: BYSListenerCallbackFunction): void {
@@ -69,7 +70,7 @@ export class YospaceAdListenerAdapter {
     ArrayUtils.remove(this.listeners[event], callback);
   }
 
-  onAdvertBreakStart(brk: AdBreak): void {
+  onAdvertBreakStart(brk: AdBreak | null): void {
     this.emitEvent({
       type: BYSListenerEvent.AD_BREAK_START,
       adBreak: brk,


### PR DESCRIPTION
## Description

AdBreaks raised by the integration can now be null, which aligns with the Yospace SDK API. It is possible for the Yospace SDK to not have had time to parse the metadata by the time the ad break triggers, which can cause the ad break to be null by the time the break starts.

Fixes a crash in the Yospace integration if ad breaks raised by the yospace sdk are null.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
