### PR TITLE
Modify DVR Live asset URLs with recommended parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Update `index.html` to use UIv4
+- Update `DVRLive` sample source to use recommended YoSpace stream parameters
+
 ## [2.10.0] - 2025-04-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -169,10 +169,15 @@ const yospaceConfig = {
 ## Recommended YoSpace DVRLive Stream Query Parameters
 
 - **Recommended**: `yo.pdt=true` and `yo.lpa=dur`
+
   The ad server generates a continuous timeline based on the actual segment durations, calculating PDT tags that match the sum of those durations. This ensures full compatibility with the latest Bitmovin Player’s behavior and expectations.
+
 - **Not Recommended**: `yo.pdt=sync` and `yo.lpa=true`
+
   The ad server aligns Program Date Time tags with the scheduled wall-clock timeline of the source, prioritizing schedule alignment over actual ad duration. If an ad break exceeds its planned length (for example, 34s in a 30s slot), the manifest enforces a timeline reset causing recent player versions (`v8.184.0+`) to skip content to realign.
+
 - **Deprecated**: `yo.pdt=false` (or omitting `yo.pdt`)
+
   No Program Date Time tags are generated. This mode is deprecated and no longer recommended.
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ const yospaceConfig = {
 - Run `npm run build-tv`
 - Open the `WebOS` folder in Visual Studio Code with the WebOS TV extension, or use the WebOS CLI directly.
 
+## Recommended YoSpace DVRLive Stream Query Parameters
+
+- **Recommended**: `yo.pdt=true` and `yo.lpa=dur`
+  The ad server generates a continuous timeline based on the actual segment durations, calculating PDT tags that match the sum of those durations. This ensures full compatibility with the latest Bitmovin Player’s behavior and expectations.
+- **Not Recommended**: `yo.pdt=sync` and `yo.lpa=true`
+  The ad server aligns Program Date Time tags with the scheduled wall-clock timeline of the source, prioritizing schedule alignment over actual ad duration. If an ad break exceeds its planned length (for example, 34s in a 30s slot), the manifest enforces a timeline reset causing recent player versions (`v8.184.0+`) to skip content to realign.
+- **Deprecated**: `yo.pdt=false` (or omitting `yo.pdt`)
+  No Program Date Time tags are generated. This mode is deprecated and no longer recommended.
+
 ## Limitations
 
 - No support for ad tracking during live streams in Safari if EMSG tags are used. (EMSG tags are not supported by Safari)
@@ -186,6 +195,7 @@ const yospaceConfig = {
 - PRs should always contain an update of the [CHANGELOG.md](CHANGELOG.md) file
 
 ### Validation & Release
+
 - Especially when updating the Yospace SDK, this project should be validated following https://developer.yospace.com/sdk-documentation/javascript/userguide/yosdk/latest/en/validate-your-app.html. This can be done using the sample page with the following steps:
   1. Run `npm start`
   2. Open `localhost:8080?validation=true` in a browser

--- a/web/index.html
+++ b/web/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Bitmovin Player Yospace Integration Test Page</title>
@@ -288,10 +288,10 @@
           bitmovin.player.core.Player,
           playerContainer,
           conf,
-          yospaceConfig
+          yospaceConfig,
         );
 
-        uiManager = new bitmovin.playerui.UIFactory.buildDefaultUI(yospacePlayer);
+        uiManager = bitmovin.playerui.UIFactory.buildUI(yospacePlayer);
 
         yospacePlayer.on('sourceloaded', function (event) {
           log(createLogFromEvent(event));
@@ -350,7 +350,7 @@
                 ' mediaSequenceNumber=' +
                 event.mediaSequenceNumber +
                 ' discontinuitySequenceNumber=' +
-                event.discontinuitySequenceNumber
+                event.discontinuitySequenceNumber,
             );
           }
         });

--- a/web/js/sources.js
+++ b/web/js/sources.js
@@ -30,8 +30,8 @@ var sources = {
     },
     dvrLive: {
       title: 'DVR Live',
-      // dash: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,dash-mp4-pre.mpd?yo.br=false&yo.av=4&yo.lp=true',
-      hls: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true',
+      // dash: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,dash-mp4-pre.mpd?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur',
+      hls: 'https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur',
       // Yospace configuration
       assetType: bitmovin.player.ads.yospace.YospaceAssetType.DVRLIVE,
     },


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
**Core Issue:** Actual Ad duration rarely matches the scheduled Ad Break duration.
**Context:** Bitmovin Player (`v8.184.0+`) changed its time handling. It now strictly respects Manifest PDT (absolute time) tags rather than internally summing segment durations and keeping an internal state updated.
**Solution:** Update the YoSpace stream parameters to use the recommended `yo.pdt=true` and `yo.lpa=dur`.

**YoSpace Query Parameters**:
1. `yo.pdt=true` + `yo.lpa=dur` (Recommended)
The ad server generates a continuous timeline based on the **actual** segment durations, calculating PDT tags that match the sum of those durations.
**Manifest Example (Continuous):**
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:10

# ... Live Content ...
#EXT-X-PROGRAM-DATE-TIME:2024-02-09T12:00:00.000Z
#EXTINF:10.0,
content_segment_1.ts

# --- AD BREAK START ---
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2024-02-09T12:00:10.000Z
#EXTINF:10.0,
ad_segment_1.ts
#EXTINF:10.0,
ad_segment_2.ts
#EXTINF:10.0,
ad_segment_3.ts
#EXTINF:4.0,  <-- EXTRA 4s (Total Ad = 34s)
ad_segment_4.ts

# --- AD BREAK END ---
#EXT-X-DISCONTINUITY
# ✅ CONTINUOUS: Resumes at T+34s (Actual End of Ad)
# The player's internal clock matches the manifest. No Jump.
#EXT-X-PROGRAM-DATE-TIME:2024-02-09T12:00:44.000Z
#EXTINF:10.0,
content_resumes.ts
```
2. `yo.pdt=sync` + `yo.lpa=true` (Not recommended)
The ad server aligns Program Date Time tags with the **scheduled** wall-clock time of the source, prioritizing the schedule over the actual ads duration. So, if a 34s ad exceeds a 30s break, the manifest enforces a timeline reset, causing players (`v8.184.0+`) to skip content to realign.
**Manifest Example (Forced Sync):**
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:10

# ... Live Content ...
#EXT-X-PROGRAM-DATE-TIME:2024-02-09T12:00:00.000Z
#EXTINF:10.0,
content_segment_1.ts

# --- AD BREAK START (Scheduled Duration: 30s) ---
#EXT-X-DISCONTINUITY
#EXT-X-PROGRAM-DATE-TIME:2024-02-09T12:00:10.000Z
#EXTINF:10.0,
ad_segment_1.ts
#EXTINF:10.0,
ad_segment_2.ts
#EXTINF:10.0,
ad_segment_3.ts
#EXTINF:4.0,  <-- EXTRA 4s (Total Ad = 34s)
ad_segment_4.ts

# --- AD BREAK END ---
#EXT-X-DISCONTINUITY
# ❌ FORCE SYNC: Resumes at T+30s (Schedule) instead of T+34s (Actual)
# The player's internal clock is at 12:00:44, but manifest says 12:00:40.
# RESULT: Player skips segments to realign.
#EXT-X-PROGRAM-DATE-TIME:2024-02-09T12:00:40.000Z 
#EXTINF:10.0,
content_resumes.ts
```
3. `yo.pdt=false` or no `yo.pdt` query parameter (Legacy)
No PDT tags. Deprecated/Not recommended anymore.
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:10

# ... Live Content ...
#EXTINF:10.0,
content_segment_1.ts

# --- AD BREAK START ---
#EXT-X-DISCONTINUITY
# No PDT Tag
#EXTINF:10.0,
ad_segment_1.ts
#EXTINF:10.0,
ad_segment_2.ts
#EXTINF:10.0,
ad_segment_3.ts
#EXTINF:4.0,
ad_segment_4.ts

# --- AD BREAK END ---
#EXT-X-DISCONTINUITY
# No PDT Tag
#EXTINF:10.0,
content_resumes.ts
```

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
